### PR TITLE
Vectors and records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 **/build/
 tmp/
+**/test.js

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -92,8 +92,11 @@ export const theModule = makeModule("Core", (rt, ns) => {
     append: rt.makeFunction((obj1, obj2) => {
       if (typeof obj1 === "string" && typeof obj2 === "string") {
         return obj1 + obj2;
+      } else if (obj1 instanceof Cons) {
+        return Cons.from(obj1).append(obj2);
+      } else {
+        rt.failRuntime(`Value of type ${typeof obj1} cannot be appended`);
       }
-      return obj1.append(obj2);
     }),
   };
 });

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -98,5 +98,13 @@ export const theModule = makeModule("Core", (rt, ns) => {
         rt.failRuntime(`Value of type ${typeof obj1} cannot be appended`);
       }
     }),
+    with: rt.makeFunction((rec1, rec2) => {
+      const newDict = Object.assign(
+        {},
+        rt.getMetaField(rec1, "dict"),
+        rt.getMetaField(rec2, "dict")
+      );
+      return rt.makeObject(newDict);
+    }),
   };
 });

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -20,6 +20,7 @@ export const theModule = makeModule("Core", (rt, ns) => {
   };
 
   return {
+    __module__: "Core",
     print: rt.makeFunction(print),
     println: rt.makeFunction(println),
     cons,

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -94,6 +94,8 @@ export const theModule = makeModule("Core", (rt, ns) => {
         return obj1 + obj2;
       } else if (obj1 instanceof Cons) {
         return Cons.from(obj1).append(obj2);
+      } else if (Array.isArray(obj1)) {
+        return [...obj1].push(obj2);
       } else {
         rt.failRuntime(`Value of type ${typeof obj1} cannot be appended`);
       }

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -52,7 +52,7 @@ export const theModule = makeModule("Core", (rt, ns) => {
     "<": rt.makeFunction((a, b) => a < b),
     "<=": rt.makeFunction((a, b) => a <= b),
     not: rt.makeFunction((x) => !x),
-    list: rt.makeFunction((...args) => Cons.of(...args)),
+    list: rt.makeFunction((...args) => Cons.from(args)),
     length: rt.makeFunction((obj) => {
       if (obj instanceof Cons) {
         let i = 0;
@@ -106,5 +106,6 @@ export const theModule = makeModule("Core", (rt, ns) => {
       );
       return rt.makeObject(newDict);
     }),
+    prop: rt.makeFunction((prop, obj) => rt.getField(obj, prop)),
   };
 });

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -82,7 +82,12 @@ export const theModule = makeModule("Core", (rt, ns) => {
     "keyword?": rt.makeFunction(
       (obj) => typeof obj === "symbol" && obj.description.startsWith(":")
     ),
-    "equal?": rt.makeFunction((a, b) => equal(a, b)),
+    "equal?": rt.makeFunction((a, b) => {
+      if (rt.hasDict(a) && rt.hasDict(b)) {
+        return equal(rt.getMetaField(a, "dict"), rt.getMetaField(b, "dict"));
+      }
+      return equal(a, b);
+    }),
     "is?": rt.makeFunction((a, b) => Object.is(a, b)),
     append: rt.makeFunction((obj1, obj2) => {
       if (typeof obj1 === "string" && typeof obj2 === "string") {

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -20,7 +20,7 @@ export const theModule = makeModule("Core", (rt, ns) => {
   };
 
   return {
-    __module__: "Core",
+    __module__: "Global",
     print: rt.makeFunction(print),
     println: rt.makeFunction(println),
     cons,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.1",
         "esbuild": "^0.17.19",
         "fast-deep-equal": "^3.1.3",
         "object-hash": "^3.0.0",
@@ -1280,6 +1281,25 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.1.tgz",
+      "integrity": "sha512-GJhHYlMhyT2gWemDL7BGMWfTNhspJKkikLKh9wAy3z4GTTINvTYALkUd+eGQK7aLeVkVzPuSA0VCT3H5eEWbbw==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/jasonsbarr/wanda#readme",
   "dependencies": {
+    "@paralleldrive/cuid2": "^2.2.1",
     "esbuild": "^0.17.19",
     "fast-deep-equal": "^3.1.3",
     "object-hash": "^3.0.0",

--- a/src/cli/repl.js
+++ b/src/cli/repl.js
@@ -61,6 +61,7 @@ export const repl = (mode = "repl") => {
           }
       }
     } catch (e) {
+      console.error(e.message);
       console.error(e.stack);
     }
   }

--- a/src/cli/repl.js
+++ b/src/cli/repl.js
@@ -61,7 +61,6 @@ export const repl = (mode = "repl") => {
           }
       }
     } catch (e) {
-      console.error(e.message);
       console.error(e.stack);
     }
   }

--- a/src/cli/repl.js
+++ b/src/cli/repl.js
@@ -61,7 +61,7 @@ export const repl = (mode = "repl") => {
           }
       }
     } catch (e) {
-      console.error(e.message);
+      console.error(e.stack);
     }
   }
 };

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -1,5 +1,5 @@
 import { ASTTypes } from "../parser/ast.js";
-import { Exception, SyntaxException } from "../shared/exceptions.js";
+import { ReferenceException, SyntaxException } from "../shared/exceptions.js";
 import { Namespace } from "../shared/Namespace.js";
 import { makeSymbol } from "../runtime/makeSymbol.js";
 
@@ -192,8 +192,9 @@ export class Emitter {
     const emittedName = ns.get(name);
 
     if (!emittedName) {
-      throw new Exception(
-        `The name ${name} has not been defined in ${node.srcloc.file} at ${node.srcloc.line}:${node.srcloc.col}`
+      throw new ReferenceException(
+        `Cannot access name ${name} before its definition`,
+        srcloc
       );
     }
 
@@ -225,8 +226,9 @@ export class Emitter {
     const name = node.lhv.name;
 
     if (ns.has(name)) {
-      throw new Exception(
-        `Name ${name} defined at ${node.srcloc.file} ${node.srcloc.line}:${node.srcloc.col} has already been accessed in the current namespace; cannot access identifier before defining it`
+      throw new ReferenceException(
+        `Name ${name} has already been accessed in the current namespace; cannot access name before its definition`,
+        node.srcloc
       );
     }
 

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -133,7 +133,7 @@ export class Emitter {
    * @returns {string}
    */
   emitNil(node, ns) {
-    return `rt.makeWandaValue(${"null"})`;
+    return `rt.makeWandaValue(${null})`;
   }
 
   /**

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -77,7 +77,7 @@ export class Emitter {
    * @returns {string}
    */
   emitBoolean(node, ns) {
-    return node.value;
+    return `rt.makeWandaValue(${node.value})`;
   }
 
   /**
@@ -133,7 +133,7 @@ export class Emitter {
    * @returns {string}
    */
   emitNil(node, ns) {
-    return "null";
+    return `rt.makeWandaValue(${"null"})`;
   }
 
   /**
@@ -143,7 +143,7 @@ export class Emitter {
    * @returns {string}
    */
   emitNumber(node, ns) {
-    return node.value;
+    return `rt.makeWandaValue(${node.value})`;
   }
 
   /**
@@ -178,7 +178,7 @@ export class Emitter {
    * @returns {string}
    */
   emitString(node, ns) {
-    return "`" + node.value.slice(1, -1) + "`";
+    return `rt.makeWandaValue(${"`" + node.value.slice(1, -1) + "`"})`;
   }
 
   /**

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -173,7 +173,22 @@ export class Emitter {
     return code;
   }
 
-  emitRecordLiteral(node, ns) {}
+  /**
+   * Generates code from a RecordLiteral node
+   * @param {import("../parser/ast.js").RecordLiteral} node
+   * @param {Namespace} ns
+   * @returns {string}
+   */
+  emitRecordLiteral(node, ns) {
+    let code = "({";
+
+    for (let prop of node.properties) {
+      code += `"${prop.key.name}": ${this.emit(prop.value, ns)}`;
+    }
+
+    code += "})";
+    return code;
+  }
 
   emitRecordPattern(node, ns) {}
 

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -322,6 +322,7 @@ export class Emitter {
   emitVariableDeclarationAssignment(lhv, rhv, ns) {
     if (lhv.kind === ASTTypes.Symbol) {
       return `var ${makeSymbol(lhv.name)} = ${this.emit(rhv, ns)}`;
+    } else if (lhv.kind === ASTTypes.VectorPattern) {
     } else if (lhv.kind === ASTTypes.RecordPattern) {
       // create random variable name to hold object being destructured
       const gensym = makeGenSym();
@@ -362,7 +363,22 @@ export class Emitter {
     }
   }
 
-  emitVectorLiteral(node, ns) {}
+  /**
+   * Generates code from a VectorLiteral node
+   * @param {import("../parser/ast.js").VectorLiteral} node
+   * @param {Namespace} ns
+   * @returns {string}
+   */
+  emitVectorLiteral(node, ns) {
+    let code = "rt.makeWandaValue([";
+
+    for (let mem of node.members) {
+      code += `${this.emit(mem, ns)}, `;
+    }
+
+    code += "])";
+    return code;
+  }
 
   emitVectorPattern(node, ns) {}
 }

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -317,7 +317,8 @@ export class Emitter {
     } else if (lhv.kind === ASTTypes.VectorPattern) {
       return `var ${this.emit(lhv, ns)} = ${this.emit(rhv, ns)}`;
     } else if (lhv.kind === ASTTypes.RecordPattern) {
-      // create random variable name to hold object being destructured
+      /* Note that this DOES NOT WORK on rest variables in nested record patterns */
+      // create random variable to hold object being destructured
       const gensym = makeGenSym();
       let origObjCode = `var ${gensym} = ${this.emit(rhv, ns)}`;
       let code = `${origObjCode};\n`;

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -65,6 +65,16 @@ export class Emitter {
         return this.emitDoExpression(node, ns);
       case ASTTypes.TypeAlias:
         return this.emitTypeAlias(node, ns);
+      case ASTTypes.MemberExpression:
+        return this.emitMemberExpression(node, ns);
+      case ASTTypes.RecordLiteral:
+        return this.emitRecordLiteral(node, ns);
+      case ASTTypes.RecordPattern:
+        return this.emitRecordPattern(node, ns);
+      case ASTTypes.VectorLiteral:
+        return this.emitVectorLiteral(node, ns);
+      case ASTTypes.VectorPattern:
+        return this.emitVectorPattern(node, ns);
       default:
         throw new SyntaxException(node.kind, node.srcloc);
     }

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -306,7 +306,6 @@ export class Emitter {
         node.expression,
         ns
       )}`;
-      console.log(code);
       return code;
     }
   }

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -126,6 +126,8 @@ export class Emitter {
     return `Symbol.for("${node.value}")`;
   }
 
+  emitMemberExpression(node, ns) {}
+
   /**
    * Generates code from a Nil AST node
    * @param {import("../parser/ast.js").NilLiteral} node
@@ -160,6 +162,10 @@ export class Emitter {
 
     return code;
   }
+
+  emitRecordLiteral(node, ns) {}
+
+  emitRecordPattern(node, ns) {}
 
   /**
    * Generates code from a SetExpression AST node
@@ -233,9 +239,11 @@ export class Emitter {
     }
 
     const translatedName = makeSymbol(name);
-
     ns.set(name, translatedName);
-
     return `var ${translatedName} = ${this.emit(node.expression, ns)};`;
   }
+
+  emitVectorLiteral(node, ns) {}
+
+  emitVectorPattern(node, ns) {}
 }

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -143,7 +143,7 @@ export class Emitter {
    * @returns {string}
    */
   emitNumber(node, ns) {
-    return `rt.makeWandaValue(${node.value})`;
+    return `rt.makeNumber("${node.value}")`;
   }
 
   /**

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -136,7 +136,17 @@ export class Emitter {
     return `Symbol.for("${node.value}")`;
   }
 
-  emitMemberExpression(node, ns) {}
+  /**
+   * Generates code from a MemberExpression AST node
+   * @param {import("../parser/ast.js").MemberExpression} node
+   * @param {Namespace} ns
+   * @returns {string}
+   */
+  emitMemberExpression(node, ns) {
+    return `rt.getField(${this.emit(node.object, ns)}, "${
+      node.property.name
+    }")`;
+  }
 
   /**
    * Generates code from a Nil AST node

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -202,7 +202,7 @@ export class Emitter {
     let i = 0;
     for (let prop of node.properties) {
       if (node.rest && i === node.properties.length - 1) {
-        code += `...${makeSymbol(prop.name)}`;
+        break;
       } else {
         code += `${makeSymbol(prop.name)}, `;
       }

--- a/src/emitter/emitGlobalEnv.js
+++ b/src/emitter/emitGlobalEnv.js
@@ -8,8 +8,13 @@ export const emitGlobalEnv = () => {
     ROOT_PATH,
     "./src/runtime/makeGlobals.js"
   )}";
+import { makeRuntime } from "${path.join(
+    ROOT_PATH,
+    "./src/runtime/makeRuntime.js"
+  )}";
 
 const globalEnv = makeGlobal();
+const rt = makeRuntime();
 `;
 
   for (let [k] of globalEnv) {

--- a/src/emitter/emitGlobalEnv.js
+++ b/src/emitter/emitGlobalEnv.js
@@ -14,7 +14,7 @@ import { makeRuntime } from "${path.join(
   )}";
 
 const globalEnv = makeGlobal();
-const rt = makeRuntime();
+rt = makeRuntime();
 `;
 
   for (let [k] of globalEnv) {

--- a/src/lexer/Lexer.js
+++ b/src/lexer/Lexer.js
@@ -4,6 +4,7 @@ import { SrcLoc } from "./SrcLoc.js";
 import { Token } from "./Token.js";
 import { TokenTypes } from "./TokenTypes.js";
 import {
+  isAmp,
   isBoolean,
   isColon,
   isDash,
@@ -259,6 +260,12 @@ export class Lexer {
         this.input.next(); // skip over punc
         tokens.push(
           Token.new(TokenTypes.Dot, ch, SrcLoc.new(pos, line, col, file))
+        );
+      } else if (isAmp(ch)) {
+        const { pos, line, col, file } = this.input;
+        this.input.next(); // skip over punc
+        tokens.push(
+          Token.new(TokenTypes.Amp, ch, SrcLoc.new(pos, line, col, file))
         );
       } else {
         const { pos, line, col, file } = this.input;

--- a/src/lexer/Lexer.js
+++ b/src/lexer/Lexer.js
@@ -254,6 +254,12 @@ export class Lexer {
         tokens.push(
           Token.new(TokenTypes.RBrace, ch, SrcLoc.new(pos, line, col, file))
         );
+      } else if (isDot(ch)) {
+        const { pos, line, col, file } = this.input;
+        this.input.next(); // skip over punc
+        tokens.push(
+          Token.new(TokenTypes.Dot, ch, SrcLoc.new(pos, line, col, file))
+        );
       } else {
         const { pos, line, col, file } = this.input;
         throw new SyntaxException(ch, SrcLoc.new(pos, line, col, file));

--- a/src/lexer/Lexer.js
+++ b/src/lexer/Lexer.js
@@ -10,11 +10,15 @@ import {
   isDigit,
   isDot,
   isDoubleQuote,
+  isLBrace,
+  isLBrack,
   isLParen,
   isNewline,
   isNil,
   isNumber,
   isPlus,
+  isRBrace,
+  isRBrack,
   isRParen,
   isSemicolon,
   isSymbolChar,
@@ -225,6 +229,30 @@ export class Lexer {
         this.input.next(); // skip over punc
         tokens.push(
           Token.new(TokenTypes.RParen, ch, SrcLoc.new(pos, line, col, file))
+        );
+      } else if (isLBrack(ch)) {
+        const { pos, line, col, file } = this.input;
+        this.input.next(); // skip over punc
+        tokens.push(
+          Token.new(TokenTypes.LBrack, ch, SrcLoc.new(pos, line, col, file))
+        );
+      } else if (isRBrack(ch)) {
+        const { pos, line, col, file } = this.input;
+        this.input.next(); // skip over punc
+        tokens.push(
+          Token.new(TokenTypes.RBrack, ch, SrcLoc.new(pos, line, col, file))
+        );
+      } else if (isLBrace(ch)) {
+        const { pos, line, col, file } = this.input;
+        this.input.next(); // skip over punc
+        tokens.push(
+          Token.new(TokenTypes.LBrace, ch, SrcLoc.new(pos, line, col, file))
+        );
+      } else if (isRBrace(ch)) {
+        const { pos, line, col, file } = this.input;
+        this.input.next(); // skip over punc
+        tokens.push(
+          Token.new(TokenTypes.RBrace, ch, SrcLoc.new(pos, line, col, file))
         );
       } else {
         const { pos, line, col, file } = this.input;

--- a/src/lexer/TokenTypes.js
+++ b/src/lexer/TokenTypes.js
@@ -15,4 +15,5 @@ export const TokenTypes = {
   LBrace: "LBrace",
   RBrace: "RBrace",
   Dot: "Dot",
+  Amp: "Amp",
 };

--- a/src/lexer/TokenTypes.js
+++ b/src/lexer/TokenTypes.js
@@ -14,4 +14,5 @@ export const TokenTypes = {
   RBrack: "RBrack",
   LBrace: "LBrace",
   RBrace: "RBrace",
+  Dot: "Dot",
 };

--- a/src/lexer/TokenTypes.js
+++ b/src/lexer/TokenTypes.js
@@ -10,4 +10,8 @@ export const TokenTypes = {
   Symbol: "Symbol",
   LParen: "LParen",
   RParen: "RParen",
+  LBrack: "LBrack",
+  RBrack: "RBrack",
+  LBrace: "LBrace",
+  RBrace: "RBrace",
 };

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -13,6 +13,10 @@ export const isSymbolChar = (ch) =>
   /[:=@~<>%:&|?\\/^*&#'\p{L}\p{N}_$!+-]/u.test(ch);
 export const isLParen = (ch) => /\(/.test(ch);
 export const isRParen = (ch) => /\)/.test(ch);
+export const isLBrack = (ch) => /\[/.test(ch);
+export const isRBrack = (ch) => /\]/.test(ch);
+export const isLBrace = (ch) => /\{/.test(ch);
+export const isRBrace = (ch) => /\}/.test(ch);
 
 // String matchers
 export const isNumber = (str) => /^[+-]?\d+(\.\d+)?$/.test(str);

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -10,7 +10,7 @@ export const isDoubleQuote = (ch) => /"/.test(ch);
 export const isColon = (ch) => /:/.test(ch);
 export const isSymbolStart = (ch) => /[=<>%|?\\/*\p{L}_$!+-]/u.test(ch);
 export const isSymbolChar = (ch) =>
-  /[:=@~<>%:&|?\\/^*&#'\p{L}\p{N}_$!+-]/u.test(ch);
+  /[:=@~<>%&|?\\/^*&#'\p{L}\p{N}_$!+-]/u.test(ch);
 export const isLParen = (ch) => /\(/.test(ch);
 export const isRParen = (ch) => /\)/.test(ch);
 export const isLBrack = (ch) => /\[/.test(ch);

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -17,6 +17,7 @@ export const isLBrack = (ch) => /\[/.test(ch);
 export const isRBrack = (ch) => /\]/.test(ch);
 export const isLBrace = (ch) => /\{/.test(ch);
 export const isRBrace = (ch) => /\}/.test(ch);
+export const isAmp = (ch) => /&/.test(ch);
 
 // String matchers
 export const isNumber = (str) => /^[+-]?\d+(\.\d+)?$/.test(str);

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -8,7 +8,7 @@ export const isDash = (ch) => /\-/.test(ch);
 export const isPlus = (ch) => /\+/.test(ch);
 export const isDoubleQuote = (ch) => /"/.test(ch);
 export const isColon = (ch) => /:/.test(ch);
-export const isSymbolStart = (ch) => /[=<>%:|?\\/*\p{L}_$!+-]/u.test(ch);
+export const isSymbolStart = (ch) => /[=<>%|?\\/*\p{L}_$!+-]/u.test(ch);
 export const isSymbolChar = (ch) =>
   /[:=@~<>%:&|?\\/^*&#'\p{L}\p{N}_$!+-]/u.test(ch);
 export const isLParen = (ch) => /\(/.test(ch);

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -10,7 +10,7 @@ export const isDoubleQuote = (ch) => /"/.test(ch);
 export const isColon = (ch) => /:/.test(ch);
 export const isSymbolStart = (ch) => /[=<>%|?\\/*\p{L}_$!+-]/u.test(ch);
 export const isSymbolChar = (ch) =>
-  /[:=@~<>%&|?\\/^*&#'\p{L}\p{N}_$!+-]/u.test(ch);
+  /[=@~<>%&|?\\/^*&#'\p{L}\p{N}_$!+-]/u.test(ch);
 export const isLParen = (ch) => /\(/.test(ch);
 export const isRParen = (ch) => /\)/.test(ch);
 export const isLBrack = (ch) => /\[/.test(ch);

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -65,7 +65,7 @@ export const ASTTypes = {
  * @typedef {NumberLiteral|StringLiteral|BooleanLiteral|KeywordLiteral|NilLiteral} Primitive
  */
 /**
- * @typedef {Program|Primitive|Symbol|CallExpression|VariableDeclaration|SetExpression|DoExpression} AST
+ * @typedef {Program|Primitive|Symbol|CallExpression|VariableDeclaration|SetExpression|DoExpression|TypeAlias} AST
  */
 export const AST = {
   /**

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -65,7 +65,7 @@ export const ASTTypes = {
  * @typedef {NumberLiteral|StringLiteral|BooleanLiteral|KeywordLiteral|NilLiteral} Primitive
  */
 /**
- * @typedef {Program|NumberLiteral|StringLiteral|BooleanLiteral|KeywordLiteral|NilLiteral|Symbol|CallExpression|VariableDeclaration|SetExpression|DoExpression} AST
+ * @typedef {Program|Primitive|Symbol|CallExpression|VariableDeclaration|SetExpression|DoExpression} AST
  */
 export const AST = {
   /**

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -17,6 +17,11 @@ export const ASTTypes = {
   SetExpression: "SetExpression",
   DoExpression: "DoExpression",
   TypeAlias: "TypeAlias",
+  VectorLiteral: "VectorLiteral",
+  VectorPattern: "VectorPattern",
+  Property: "Property",
+  RecordLiteral: "RecordLiteral",
+  RecordPattern: "RecordPattern",
 };
 
 /**
@@ -47,19 +52,34 @@ export const ASTTypes = {
  * @typedef {ASTNode & {kind: ASTTypes.Symbol; name: string}} Symbol
  */
 /**
- * @typedef {ASTNode & {func: AST, args: AST[]}} CallExpression
+ * @typedef {ASTNode & {kind: ASTTypes.CallExpression; func: AST, args: AST[]}} CallExpression
  */
 /**
- * @typedef {ASTNode & {lhv: AST, expression: AST, typeAnnotation?: null | import("./parseTypeAnnotation.js").TypeAnnotation}} VariableDeclaration
+ * @typedef {ASTNode & {kind: ASTTypes.VariableDeclaration; lhv: AST, expression: AST, typeAnnotation?: null | import("./parseTypeAnnotation.js").TypeAnnotation}} VariableDeclaration
  */
 /**
- * @typedef {ASTNode & {lhv: AST, expression: AST}} SetExpression
+ * @typedef {ASTNode & {kind: ASTTypes.SetExpression; lhv: AST, expression: AST}} SetExpression
  */
 /**
- * @typedef {ASTNode & {body: AST[]}} DoExpression
+ * @typedef {ASTNode & {kind: ASTTypes.DoExpression; body: AST[]}} DoExpression
  */
 /**
- * @typedef {ASTNode & {name: string; type: import("./parseTypeAnnotation.js").TypeAnnotation}} TypeAlias
+ * @typedef {ASTNode & {kind: ASTTypes.TypeAlias; name: string; type: import("./parseTypeAnnotation.js").TypeAnnotation}} TypeAlias
+ */
+/**
+ * @typedef {ASTNode & {kind: ASTTypes.VectorLiteral; members: AST[]}} VectorLiteral
+ */
+/**
+ * @typedef {ASTNode & {kind: ASTTypes.VectorPattern; members: Symbol[]}} VectorPattern
+ */
+/**
+ * @typedef {ASTNode & {kind: ASTTypes.Property; key: Symbol; value: AST}} Property
+ */
+/**
+ * @typedef {ASTNode & {kind: ASTTypes.RecordLiteral; properties: Property[]}} RecordLiteral
+ */
+/**
+ * @typedef {ASTNode & {kind: ASTTypes.RecordPattern; properties: Symbol[]}} RecordPattern
  */
 /**
  * @typedef {NumberLiteral|StringLiteral|BooleanLiteral|KeywordLiteral|NilLiteral} Primitive

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -83,7 +83,7 @@ export const ASTTypes = {
  * @typedef {ASTNode & {kind: ASTTypes.RecordPattern; properties: Symbol[]; rest: boolean}} RecordPattern
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.MemberExpression; object: AST; property: AST}} MemberExpression
+ * @typedef {ASTNode & {kind: ASTTypes.MemberExpression; object: AST; property: Symbol}} MemberExpression
  */
 /**
  * @typedef {NumberLiteral|StringLiteral|BooleanLiteral|KeywordLiteral|NilLiteral} Primitive

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -71,7 +71,7 @@ export const ASTTypes = {
  * @typedef {ASTNode & {kind: ASTTypes.VectorLiteral; members: AST[]}} VectorLiteral
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.VectorPattern; members: Symbol[]; rest: boolean}} VectorPattern
+ * @typedef {ASTNode & {kind: ASTTypes.VectorPattern; members: (Symbol|VectorPattern|RecordPattern)[]; rest: boolean}} VectorPattern
  */
 /**
  * @typedef {ASTNode & {kind: ASTTypes.Property; key: Symbol; value: AST}} Property
@@ -80,7 +80,7 @@ export const ASTTypes = {
  * @typedef {ASTNode & {kind: ASTTypes.RecordLiteral; properties: Property[]}} RecordLiteral
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.RecordPattern; properties: Symbol[]; rest: boolean}} RecordPattern
+ * @typedef {ASTNode & {kind: ASTTypes.RecordPattern; properties: (Symbol|VectorPattern|RecordPattern)[]; rest: boolean}} RecordPattern
  */
 /**
  * @typedef {ASTNode & {kind: ASTTypes.MemberExpression; object: AST; property: Symbol}} MemberExpression

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -71,7 +71,7 @@ export const ASTTypes = {
  * @typedef {ASTNode & {kind: ASTTypes.VectorLiteral; members: AST[]}} VectorLiteral
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.VectorPattern; members: Symbol[]}} VectorPattern
+ * @typedef {ASTNode & {kind: ASTTypes.VectorPattern; members: Symbol[]; rest: boolean}} VectorPattern
  */
 /**
  * @typedef {ASTNode & {kind: ASTTypes.Property; key: Symbol; value: AST}} Property
@@ -80,7 +80,7 @@ export const ASTTypes = {
  * @typedef {ASTNode & {kind: ASTTypes.RecordLiteral; properties: Property[]}} RecordLiteral
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.RecordPattern; properties: Symbol[]}} RecordPattern
+ * @typedef {ASTNode & {kind: ASTTypes.RecordPattern; properties: Symbol[]; rest: boolean}} RecordPattern
  */
 /**
  * @typedef {ASTNode & {kind: ASTTypes.MemberExpression; object: AST; property: AST}} MemberExpression
@@ -256,13 +256,15 @@ export const AST = {
    * Constructs a VectorPattern AST node
    * @param {Symbol[]} members
    * @param {SrcLoc} srcloc
+   * @param {boolean} [rest=false]
    * @returns {VectorPattern}
    */
-  VectorPattern(members, srcloc) {
+  VectorPattern(members, srcloc, rest = false) {
     return {
       kind: ASTTypes.VectorPattern,
       members,
       srcloc,
+      rest,
     };
   },
   /**
@@ -297,13 +299,15 @@ export const AST = {
    * Constructs a RecordPattern AST node
    * @param {Symbol[]} properties
    * @param {SrcLoc} srcloc
+   * @param {boolean} [rest=false]
    * @returns {RecordPattern}
    */
-  RecordPattern(properties, srcloc) {
+  RecordPattern(properties, srcloc, rest = false) {
     return {
       kind: ASTTypes.RecordPattern,
       properties,
       srcloc,
+      rest,
     };
   },
   /**

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -252,10 +252,40 @@ export const AST = {
       srcloc,
     };
   },
-  VectorPattern() {},
-  VectorLiteral() {},
-  Property() {},
-  RecordPattern() {},
-  RecordLiteral() {},
-  MemberExpression() {},
+  /**
+   * Constructs a VectorPattern AST node
+   * @param {import("../reader/read.js").VectorLiteral} form
+   * @returns {VectorPattern}
+   */
+  VectorPattern(form) {},
+  /**
+   * Constructs a VectorLiteral AST node
+   * @param {import("../reader/read.js").VectorLiteral} form
+   * @returns {VectorLiteral}
+   */
+  VectorLiteral(form) {},
+  /**
+   * Constructs a Property AST node
+   * @param {import("../reader/read.js").Property} form
+   * @returns {Property}
+   */
+  Property(form) {},
+  /**
+   * Constructs a RecordPattern AST node
+   * @param {import("../reader/read.js").RecordPattern} form
+   * @returns {RecordPattern}
+   */
+  RecordPattern(form) {},
+  /**
+   * Constructs a RecordLiteral AST node
+   * @param {import("../reader/read.js").RecordLiteral} form
+   * @returns {RecordLiteral}
+   */
+  RecordLiteral(form) {},
+  /**
+   * Constructs a MemberExpression AST node
+   * @param {import("../reader/read.js").MemberExpression} form
+   * @returns {MemberExpression}
+   */
+  MemberExpression(form) {},
 };

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -59,7 +59,7 @@ export const ASTTypes = {
  * @typedef {ASTNode & {kind: ASTTypes.VariableDeclaration; lhv: AST, expression: AST, typeAnnotation?: null | import("./parseTypeAnnotation.js").TypeAnnotation}} VariableDeclaration
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.SetExpression; lhv: AST, expression: AST}} SetExpression
+ * @typedef {ASTNode & {kind: ASTTypes.SetExpression; lhv: LHV, expression: AST}} SetExpression
  */
 /**
  * @typedef {ASTNode & {kind: ASTTypes.DoExpression; body: AST[]}} DoExpression
@@ -84,6 +84,9 @@ export const ASTTypes = {
  */
 /**
  * @typedef {ASTNode & {kind: ASTTypes.MemberExpression; object: AST; property: Symbol}} MemberExpression
+ */
+/**
+ * @typedef {Symbol|VectorPattern|RecordPattern} LHV
  */
 /**
  * @typedef {NumberLiteral|StringLiteral|BooleanLiteral|KeywordLiteral|NilLiteral} Primitive

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -22,6 +22,7 @@ export const ASTTypes = {
   Property: "Property",
   RecordLiteral: "RecordLiteral",
   RecordPattern: "RecordPattern",
+  MemberExpression: "MemberExpression",
 };
 
 /**
@@ -80,6 +81,9 @@ export const ASTTypes = {
  */
 /**
  * @typedef {ASTNode & {kind: ASTTypes.RecordPattern; properties: Symbol[]}} RecordPattern
+ */
+/**
+ * @typedef {ASTNode & {kind: ASTTypes.MemberExpression; object: AST; property: AST}} MemberExpression
  */
 /**
  * @typedef {NumberLiteral|StringLiteral|BooleanLiteral|KeywordLiteral|NilLiteral} Primitive

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -252,4 +252,10 @@ export const AST = {
       srcloc,
     };
   },
+  VectorPattern() {},
+  VectorLiteral() {},
+  Property() {},
+  RecordPattern() {},
+  RecordLiteral() {},
+  MemberExpression() {},
 };

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -254,38 +254,84 @@ export const AST = {
   },
   /**
    * Constructs a VectorPattern AST node
-   * @param {import("../reader/read.js").VectorLiteral} form
+   * @param {Symbol[]} members
+   * @param {SrcLoc} srcloc
    * @returns {VectorPattern}
    */
-  VectorPattern(form) {},
+  VectorPattern(members, srcloc) {
+    return {
+      kind: ASTTypes.VectorPattern,
+      members,
+      srcloc,
+    };
+  },
   /**
    * Constructs a VectorLiteral AST node
-   * @param {import("../reader/read.js").VectorLiteral} form
+   * @param {AST[]} members
+   * @param {SrcLoc} srcloc
    * @returns {VectorLiteral}
    */
-  VectorLiteral(form) {},
+  VectorLiteral(members, srcloc) {
+    return {
+      kind: ASTTypes.VectorLiteral,
+      members,
+      srcloc,
+    };
+  },
   /**
    * Constructs a Property AST node
-   * @param {import("../reader/read.js").Property} form
+   * @param {Symbol} key
+   * @param {AST} value
+   * @param {SrcLoc} srcloc
    * @returns {Property}
    */
-  Property(form) {},
+  Property(key, value, srcloc) {
+    return {
+      kind: ASTTypes.Property,
+      key,
+      value,
+      srcloc,
+    };
+  },
   /**
    * Constructs a RecordPattern AST node
-   * @param {import("../reader/read.js").RecordPattern} form
+   * @param {Symbol[]} properties
+   * @param {SrcLoc} srcloc
    * @returns {RecordPattern}
    */
-  RecordPattern(form) {},
+  RecordPattern(properties, srcloc) {
+    return {
+      kind: ASTTypes.RecordPattern,
+      properties,
+      srcloc,
+    };
+  },
   /**
    * Constructs a RecordLiteral AST node
-   * @param {import("../reader/read.js").RecordLiteral} form
+   * @param {Property[]} properties
+   * @param {SrcLoc} srcloc
    * @returns {RecordLiteral}
    */
-  RecordLiteral(form) {},
+  RecordLiteral(properties, srcloc) {
+    return {
+      kind: ASTTypes.RecordLiteral,
+      properties,
+      srcloc,
+    };
+  },
   /**
    * Constructs a MemberExpression AST node
-   * @param {import("../reader/read.js").MemberExpression} form
+   * @param {AST} object
+   * @param {AST} property
+   * @param {SrcLoc} srcloc
    * @returns {MemberExpression}
    */
-  MemberExpression(form) {},
+  MemberExpression(object, property, srcloc) {
+    return {
+      kind: ASTTypes.MemberExpression,
+      object,
+      property,
+      srcloc,
+    };
+  },
 };

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -111,8 +111,17 @@ const convertVectorLiteralToVectorPattern = (parsedLhv) => {
       continue;
     }
 
-    if (mem.kind !== ASTTypes.Symbol) {
-      throw new SyntaxException(mem.kind, mem.srcloc, ASTTypes.Symbol);
+    if (mem.kind === ASTTypes.VectorLiteral) {
+      mem = convertVectorLiteralToVectorPattern(mem);
+    } else if (
+      mem.kind !== ASTTypes.Symbol &&
+      mem.kind !== ASTTypes.RecordPattern
+    ) {
+      throw new SyntaxException(
+        mem.kind,
+        mem.srcloc,
+        `${ASTTypes.Symbol} or ${ASTTypes.RecordPattern}`
+      );
     }
 
     members.push(mem);

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -175,6 +175,10 @@ const parseComplexForm = (form) => {
           continue;
         }
 
+        if (prop instanceof Token && prop.type !== TokenTypes.Symbol) {
+          throw new SyntaxException(prop.type, prop.srcloc, TokenTypes.Symbol);
+        }
+
         properties.push(parseExpr(prop));
       }
 

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -50,7 +50,6 @@ const parseCall = (callExpression) => {
 
   return AST.CallExpression(parsedFunc, parsedArgs, srcloc);
 };
-
 /**
  * Parses a variable declaration
  * @param {List} decl
@@ -71,6 +70,10 @@ const parseVariableDeclaration = (decl) => {
     parsedLhv = parseExpr(lhv);
   }
 
+  if (parsedLhv.kind === ASTTypes.VectorLiteral) {
+    parsedLhv = convertVectorLiteralToVectorPattern(parsedLhv);
+  }
+
   const parsedExpression = parseExpr(expression);
 
   return AST.VariableDeclaration(
@@ -89,9 +92,24 @@ const parseVariableDeclaration = (decl) => {
 const parseSetExpression = (expr) => {
   const [_, lhv, expression] = expr;
   const parsedLhv = parseExpr(lhv);
+
+  if (parsedLhv.kind === ASTTypes.VectorLiteral) {
+    parsedLhv = convertVectorLiteralToVectorPattern(parsedLhv);
+  }
+
   const parsedExpression = parseExpr(expression);
 
   return AST.SetExpression(parsedLhv, parsedExpression, expr.srcloc);
+};
+
+const convertVectorLiteralToVectorPattern = (parsedLhv) => {
+  for (let mem of parsedLhv.members) {
+    if (mem.kind !== ASTTypes.Symbol) {
+      throw new SyntaxException(mem.kind, mem.srcloc, ASTTypes.Symbol);
+    }
+  }
+  parsedLhv.kind = ASTTypes.VectorPattern;
+  return parsedLhv;
 };
 
 /**

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -2,7 +2,7 @@ import { TokenTypes } from "../lexer/TokenTypes.js";
 import { SyntaxException } from "../shared/exceptions.js";
 import { ConsReader } from "./ConsReader.js";
 import { Cons } from "../shared/cons.js";
-import { AST } from "./ast.js";
+import { AST, ASTTypes } from "./ast.js";
 import { SrcLoc } from "../lexer/SrcLoc.js";
 import { parseTypeAnnotation } from "./parseTypeAnnotation.js";
 import { Token } from "../lexer/Token.js";
@@ -128,7 +128,36 @@ const parseTypeAlias = (form) => {
  * @param {import("../reader/read.js").ComplexForm} form
  * @returns {AST}
  */
-const parseComplexForm = (form) => {};
+const parseComplexForm = (form) => {
+  switch (form.type) {
+    case "VectorLiteral": {
+      const members = form.members.map(parseExpr);
+      return { kind: ASTTypes.VectorLiteral, members, srcloc: form.srcloc };
+    }
+    case "RecordLiteral": {
+      const properties = form.properties.map(parseProperty);
+      return { kind: ASTTypes.RecordLiteral, properties, srcloc: form.srcloc };
+    }
+    case "RecordPattern": {
+      const properties = form.properties.map(parseExpr);
+      return { kind: ASTTypes.RecordPattern, properties, srcloc: form.srcloc };
+    }
+    default:
+      // this should never happen
+      throw new SyntaxException(form.type, form.srcloc);
+  }
+};
+
+/**
+ * Parses an object property
+ * @param {import("../reader/read.js").Property} form
+ * @returns {import("./ast.js").Property}
+ */
+const parseProperty = (form) => {
+  const key = parseExpr(form.key);
+  const value = parseExpr(form.value);
+  return { kind: ASTTypes.Property, key, value, srcloc: form.srcloc };
+};
 
 /**
  * Parses a list form into AST

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -150,15 +150,20 @@ const parseComplexForm = (form) => {
   switch (form.type) {
     case "VectorLiteral": {
       const members = form.members.map(parseExpr);
-      return { kind: ASTTypes.VectorLiteral, members, srcloc: form.srcloc };
+      return AST.VectorLiteral(members, form.srcloc);
     }
     case "RecordLiteral": {
       const properties = form.properties.map(parseProperty);
-      return { kind: ASTTypes.RecordLiteral, properties, srcloc: form.srcloc };
+      return AST.RecordLiteral(properties, form.srcloc);
     }
     case "RecordPattern": {
       const properties = form.properties.map(parseExpr);
-      return { kind: ASTTypes.RecordPattern, properties, srcloc: form.srcloc };
+      return AST.RecordPattern(properties, form.srcloc);
+    }
+    case "MemberExpression": {
+      const object = parseExpr(form.object);
+      const property = parseExpr(form.property);
+      return AST.MemberExpression(object, property, form.srcloc);
     }
     default:
       // this should never happen
@@ -174,7 +179,7 @@ const parseComplexForm = (form) => {
 const parseProperty = (form) => {
   const key = parseExpr(form.key);
   const value = parseExpr(form.value);
-  return { kind: ASTTypes.Property, key, value, srcloc: form.srcloc };
+  return AST.Property(key, value, form.srcloc);
 };
 
 /**

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -5,6 +5,7 @@ import { Cons } from "../shared/cons.js";
 import { AST } from "./ast.js";
 import { SrcLoc } from "../lexer/SrcLoc.js";
 import { parseTypeAnnotation } from "./parseTypeAnnotation.js";
+import { Token } from "../lexer/Token.js";
 
 /**
  * @typedef {import("./ast.js").AST} AST
@@ -123,6 +124,13 @@ const parseTypeAlias = (form) => {
 };
 
 /**
+ * Parses a complex form passed in from the reader
+ * @param {import("../reader/read.js").ComplexForm} form
+ * @returns {AST}
+ */
+const parseComplexForm = (form) => {};
+
+/**
  * Parses a list form into AST
  * @param {List} form
  * @returns {AST}
@@ -154,7 +162,11 @@ const parseExpr = (form) => {
     return parseList(form);
   }
 
-  return parsePrimitive(form);
+  if (form instanceof Token) {
+    return parsePrimitive(form);
+  }
+
+  return parseComplexForm(form);
 };
 
 /**

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -108,8 +108,8 @@ const convertVectorLiteralToVectorPattern = (parsedLhv) => {
       throw new SyntaxException(mem.kind, mem.srcloc, ASTTypes.Symbol);
     }
   }
-  parsedLhv.kind = ASTTypes.VectorPattern;
-  return parsedLhv;
+
+  return AST.VectorPattern(members, parsedLhv.srcloc);
 };
 
 /**

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -175,7 +175,7 @@ const parseComplexForm = (form) => {
           continue;
         }
 
-        properties.push(parseProperty(prop));
+        properties.push(prop);
       }
 
       return AST.RecordPattern(properties, form.srcloc, rest);

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -103,10 +103,12 @@ const parseSetExpression = (expr) => {
 };
 
 const convertVectorLiteralToVectorPattern = (parsedLhv) => {
+  let members = [];
   for (let mem of parsedLhv.members) {
     if (mem.kind !== ASTTypes.Symbol) {
       throw new SyntaxException(mem.kind, mem.srcloc, ASTTypes.Symbol);
     }
+    members.push(mem);
   }
 
   return AST.VectorPattern(members, parsedLhv.srcloc);

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -175,7 +175,7 @@ const parseComplexForm = (form) => {
           continue;
         }
 
-        properties.push(prop);
+        properties.push(parseExpr(prop));
       }
 
       return AST.RecordPattern(properties, form.srcloc, rest);

--- a/src/parser/parseTypeAnnotation.js
+++ b/src/parser/parseTypeAnnotation.js
@@ -6,6 +6,7 @@ import { Exception } from "../shared/exceptions.js";
  * @enum {string}
  */
 export const TATypes = {
+  AnyLiteral: "AnyLiteral",
   NumberLiteral: "NumberLiteral",
   StringLiteral: "StringLiteral",
   BooleanLiteral: "BooleanLiteral",
@@ -16,6 +17,10 @@ export const TATypes = {
   Vector: "Vector",
   Object: "Object",
 };
+/**
+ * @typedef AnyAnnotation
+ * @prop {TATypes.AnyLiteral} kind
+ */
 /**
  * @typedef NumberAnnotation
  * @prop {TATypes.NumberLiteral} kind
@@ -65,7 +70,7 @@ export const TATypes = {
  * @typedef {NumberAnnotation|StringAnnotation|BooleanAnnotation|KeywordAnnotation|NilAnnotation} PrimitiveAnn
  */
 /**
- * @typedef {PrimitiveAnn|SymbolAnnotation|ListAnn|VectorAnn|ObjectAnn} TypeAnnotation
+ * @typedef {AnyAnnotation|PrimitiveAnn|SymbolAnnotation|ListAnn|VectorAnn|ObjectAnn} TypeAnnotation
  */
 /**
  * Parse the listType for a list type annotation
@@ -126,6 +131,8 @@ export const parseTypeAnnotation = (annotation) => {
 
   if (annot.type === TokenTypes.Symbol) {
     switch (annot.value) {
+      case "any":
+        return { kind: TATypes.AnyLiteral };
       case "number":
         return { kind: TATypes.NumberLiteral };
       case "string":

--- a/src/printer/printString.js
+++ b/src/printer/printString.js
@@ -1,3 +1,4 @@
+import { hasDict } from "../runtime/object.js";
 import { Cons } from "../shared/cons.js";
 import { Exception } from "../shared/exceptions.js";
 
@@ -28,7 +29,9 @@ export const printString = (value, withQuotes) => {
         return printList(value);
       }
 
-      return JSON.stringify(value, null, 2);
+      return hasDict(value)
+        ? JSON.stringify(value.dict, null, 2)
+        : JSON.stringify(value, null, 2);
     default:
       throw new Exception(`Invalid print value ${value}`);
   }

--- a/src/printer/printString.js
+++ b/src/printer/printString.js
@@ -27,6 +27,8 @@ export const printString = (value, withQuotes) => {
       } else if (value.constructor?.name === "Cons") {
         return printList(value);
       }
+
+      return JSON.stringify(value, null, 2);
     default:
       throw new Exception(`Invalid print value ${value}`);
   }

--- a/src/printer/printString.js
+++ b/src/printer/printString.js
@@ -27,6 +27,8 @@ export const printString = (value, withQuotes) => {
         return "nil";
       } else if (value.constructor?.name === "Cons") {
         return printList(value);
+      } else if (Array.isArray(value)) {
+        return `[${value.map(printString).join(", ")}]`;
       }
 
       return hasDict(value)

--- a/src/printer/printString.js
+++ b/src/printer/printString.js
@@ -32,7 +32,7 @@ export const printString = (value, withQuotes) => {
       }
 
       return hasDict(value)
-        ? JSON.stringify(value.dict, null, 2)
+        ? JSON.stringify(value[Symbol.for(":dict")], null, 2)
         : JSON.stringify(value, null, 2);
     default:
       throw new Exception(`Invalid print value ${value}`);

--- a/src/printer/println.js
+++ b/src/printer/println.js
@@ -1,4 +1,4 @@
 import { printString } from "./printString.js";
 
 export const println = (input, withQuotes = true) =>
-  console.log(printString(input, withQuotes));
+  process.stdout.write(printString(input, withQuotes)) + "\n";

--- a/src/printer/println.js
+++ b/src/printer/println.js
@@ -1,4 +1,4 @@
 import { printString } from "./printString.js";
 
 export const println = (input, withQuotes = true) =>
-  process.stdout.write(printString(input, withQuotes)) + "\n";
+  process.stdout.write(printString(input, withQuotes) + "\n");

--- a/src/reader/Reader.js
+++ b/src/reader/Reader.js
@@ -38,6 +38,15 @@ export class Reader {
   }
 
   /**
+   * Gets the token at current position plus n
+   * @param {number} n
+   * @returns {Token}
+   */
+  lookahead(n = 1) {
+    return this.tokens[this.pos + n];
+  }
+
+  /**
    * Get the current token and advance the stream
    * @returns {Token}
    */

--- a/src/reader/Reader.js
+++ b/src/reader/Reader.js
@@ -1,4 +1,6 @@
 import { Token } from "../lexer/Token.js";
+import { TokenTypes } from "../lexer/TokenTypes.js";
+import { Exception } from "../shared/exceptions.js";
 
 /**
  * @class
@@ -35,6 +37,17 @@ export class Reader {
    */
   eof() {
     return this.pos >= this.length;
+  }
+
+  /**
+   * Checks expected token type against actual token type
+   * @param {TokenTypes} expected
+   * @param {TokenTypes} actual
+   */
+  expect(expected, actual) {
+    if (expected !== actual) {
+      throw new Exception(`Expected ${expected} token; got ${actual}`);
+    }
   }
 
   /**

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -5,7 +5,15 @@ import { Reader } from "./Reader.js";
 import { Cons, cons } from "../shared/cons.js";
 import { SrcLoc } from "../lexer/SrcLoc.js";
 /**
+ * @typedef VectorLiteral
+ * @prop {"VectorLiteral"} kind
+ * @prop {Form[]} members
+ * @prop {SrcLoc} srcloc
+ */
+
+/**
  * @typedef Property
+ * @prop {"Property"} kind
  * @prop {Token} name
  * @prop {Form} value
  * @prop {SrcLoc} srcloc
@@ -13,18 +21,24 @@ import { SrcLoc } from "../lexer/SrcLoc.js";
 
 /**
  * @typedef RecordLiteral
+ * @prop {"RecordLiteral"} kind
  * @prop {Property[]} properties
  * @prop {SrcLoc} srcloc
  */
 
 /**
  * @typedef RecordPattern
+ * @prop {"RecordPattern"} kind
  * @prop {Token[]} properties
  * @prop {SrcLoc} srcloc
  */
 
 /**
- * @typedef {Token|Cons|RecordLiteral|RecordPattern} Form
+ * @typedef {VectorLiteral|RecordLiteral|RecordPattern} ComplexForm
+ */
+
+/**
+ * @typedef {Token|Cons|ComplexForm} Form
  */
 
 /**
@@ -107,6 +121,13 @@ const readList = (reader) => {
 };
 
 /**
+ * Reads a vector literal
+ * @param {Reader} reader
+ * @returns {VectorLiteral}
+ */
+const readVector = (reader) => {};
+
+/**
  * Reads either a record literal or a record pattern
  * @param {Reader} reader
  * @returns {RecordLiteral|RecordPattern}
@@ -147,6 +168,8 @@ const readForm = (reader) => {
       throw new SyntaxException(tok.value, tok.srcloc);
     case TokenTypes.LParen:
       return readList(reader);
+    case TokenTypes.LBrace:
+      return readMaybeRecord(reader);
     default:
       return readAtom(reader);
   }

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -274,6 +274,7 @@ const readMemberExpression = (reader, left) => {
   const tok = reader.next();
   reader.expect(TokenTypes.Dot, tok.type);
   const property = readExpr(reader);
+  console.log(property);
   return {
     type: "MemberExpression",
     object: left,
@@ -311,7 +312,7 @@ const readForm = (reader) => {
   }
 };
 
-const getPrec = (token) => PREC[token.type] ?? 0;
+const getPrec = (token) => PREC[token?.type] ?? 0;
 
 /**
  * Reads expressions, including reader macros
@@ -343,7 +344,7 @@ export const read = (tokens) => {
   const form =
     reader.length === 0
       ? Token.new(TokenTypes.Nil, "nil", SrcLoc.new(0, 1, 1, "reader"))
-      : readForm(reader);
+      : readExpr(reader);
   let parseTree = cons(form, null);
 
   while (!reader.eof()) {

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -100,6 +100,12 @@ const readForm = (reader) => {
     case TokenTypes.RParen:
       // there shouldn't be an RParen here
       throw new SyntaxException(tok.value, tok.srcloc);
+    case TokenTypes.RBrack:
+      // there shouln't be an RBrack here
+      throw new SyntaxException(tok.value, tok.srcloc);
+    case TokenTypes.RBrace:
+      // there shouldn't be an RBrace here
+      throw new SyntaxException(tok.value, tok.srcloc);
     case TokenTypes.LParen:
       return readList(reader);
     default:

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -4,9 +4,27 @@ import { Exception, SyntaxException } from "../shared/exceptions.js";
 import { Reader } from "./Reader.js";
 import { Cons, cons } from "../shared/cons.js";
 import { SrcLoc } from "../lexer/SrcLoc.js";
+/**
+ * @typedef Property
+ * @prop {Token} name
+ * @prop {Form} value
+ * @prop {SrcLoc} srcloc
+ */
 
 /**
- * @typedef {Token | Cons} Form
+ * @typedef RecordLiteral
+ * @prop {Property[]} properties
+ * @prop {SrcLoc} srcloc
+ */
+
+/**
+ * @typedef RecordPattern
+ * @prop {Token[]} properties
+ * @prop {SrcLoc} srcloc
+ */
+
+/**
+ * @typedef {Token|Cons|RecordLiteral|RecordPattern} Form
  */
 
 /**
@@ -87,6 +105,13 @@ const readList = (reader) => {
 
   return list;
 };
+
+/**
+ * Reads either a record literal or a record pattern
+ * @param {Reader} reader
+ * @returns {Form}
+ */
+const readMaybeRecord = (reader) => {};
 
 /**
  * Reads a form from the token stream

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -79,6 +79,9 @@ const readAtom = (reader) => {
     case TokenTypes.Symbol:
       reader.skip();
       return tok;
+    case TokenTypes.Amp:
+      reader.skip();
+      return tok;
     default:
       throw new SyntaxException(tok.value, tok.srcloc);
   }

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -132,21 +132,40 @@ const readVector = (reader) => {};
  * @param {Reader} reader
  * @returns {RecordLiteral|RecordPattern}
  */
-const readMaybeRecord = (reader) => {};
+const readMaybeRecord = (reader) => {
+  let tok = reader.next();
+  const srcloc = tok.srcloc;
+  // First token after brace should always be a symbol
+  tok = reader.peek();
+
+  if (tok.type !== TokenTypes.Symbol) {
+    throw new SyntaxException(tok.value, tok.srcloc);
+  }
+
+  tok = reader.lookahead(1);
+
+  if (tok.type === TokenTypes.Keyword && tok.value === ":") {
+    return readRecordLiteral(reader, srcloc);
+  } else {
+    return readRecordPattern(reader, srcloc);
+  }
+};
 
 /**
  * Reads a record literal
  * @param {Reader} reader
+ * @param {SrcLoc} srcloc
  * @returns {RecordLiteral}
  */
-const readRecordLiteral = (reader) => {};
+const readRecordLiteral = (reader, srcloc) => {};
 
 /**
  * Reads a record pattern
  * @param {Reader} reader
+ * @param {SrcLoc} srcloc
  * @returns {RecordPattern}
  */
-const readRecordPattern = (reader) => {};
+const readRecordPattern = (reader, srcloc) => {};
 
 /**
  * Reads a form from the token stream
@@ -168,6 +187,8 @@ const readForm = (reader) => {
       throw new SyntaxException(tok.value, tok.srcloc);
     case TokenTypes.LParen:
       return readList(reader);
+    case TokenTypes.LBrack:
+      return readVector(reader);
     case TokenTypes.LBrace:
       return readMaybeRecord(reader);
     default:

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -116,9 +116,7 @@ const readList = (reader) => {
   while (tok?.type !== TokenTypes.RParen) {
     if (!tok) {
       // Whoops, we're past the end of the token stream without ending the list
-      throw new Exception(
-        `Expected ); got EOF at ${lastTok.srcloc.line}:${lastTok.srcloc.col}`
-      );
+      throw new SyntaxException("EOF", lastTok.srcloc, ")");
     }
 
     list.append(readExpr(reader));
@@ -141,12 +139,18 @@ const readVector = (reader) => {
   // Get srcloc info from opening bracket and skip it
   let tok = reader.next();
   const srcloc = tok.srcloc;
+  let lastTok = tok;
   tok = reader.peek();
   /** @type {Form[]} */
   let members = [];
 
-  while (tok.type !== TokenTypes.RBrack) {
+  while (tok?.type !== TokenTypes.RBrack) {
+    if (!tok) {
+      throw new SyntaxException("EOF", lastTok.srcloc, "]");
+    }
+
     members.push(readExpr(reader));
+    lastTok = tok;
     tok = reader.peek();
   }
 
@@ -219,10 +223,16 @@ const readRecordLiteral = (reader, srcloc) => {
   let tok = reader.peek();
   /** @type {Property[]} */
   let properties = [];
+  let lastTok = tok;
 
-  while (tok.type !== TokenTypes.RBrace) {
+  while (tok?.type !== TokenTypes.RBrace) {
+    if (!tok) {
+      throw new SyntaxException("EOF", lastTok.srcloc, "}");
+    }
+
     reader.expect(TokenTypes.Symbol, tok.type);
     properties.push(readProperty(reader));
+    lastTok = tok;
     tok = reader.peek();
   }
 
@@ -246,11 +256,19 @@ const readRecordPattern = (reader, srcloc) => {
   /** @type {Token[]} */
   let properties = [];
   let tok = reader.peek();
+  let lastTok = tok;
 
-  while (tok.type !== TokenTypes.RBrace) {
+  while (tok?.type !== TokenTypes.RBrace) {
+    if (!tok) {
+      if (!tok) {
+        throw new SyntaxException("EOF", lastTok.srcloc, "}");
+      }
+    }
+
     tok = reader.peek();
     reader.expect(TokenTypes.Symbol, tok.type);
     properties.push(readExpr(reader));
+    lastTok = tok;
     tok = reader.peek();
   }
 

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -295,7 +295,6 @@ const readMemberExpression = (reader, left) => {
   const tok = reader.next();
   reader.expect(TokenTypes.Dot, tok.type);
   const property = readExpr(reader);
-  console.log(property);
   return {
     type: "MemberExpression",
     object: left,

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -109,9 +109,23 @@ const readList = (reader) => {
 /**
  * Reads either a record literal or a record pattern
  * @param {Reader} reader
- * @returns {Form}
+ * @returns {RecordLiteral|RecordPattern}
  */
 const readMaybeRecord = (reader) => {};
+
+/**
+ * Reads a record literal
+ * @param {Reader} reader
+ * @returns {RecordLiteral}
+ */
+const readRecordLiteral = (reader) => {};
+
+/**
+ * Reads a record pattern
+ * @param {Reader} reader
+ * @returns {RecordPattern}
+ */
+const readRecordPattern = (reader) => {};
 
 /**
  * Reads a form from the token stream

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -42,7 +42,7 @@ import { SrcLoc } from "../lexer/SrcLoc.js";
  */
 
 /**
- * @typedef {VectorLiteral|RecordLiteral|RecordPattern} ComplexForm
+ * @typedef {VectorLiteral|RecordLiteral|RecordPattern|MemberExpression} ComplexForm
  */
 
 /**

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -150,6 +150,9 @@ const readVector = (reader) => {
     tok = reader.peek();
   }
 
+  // skip closing bracket
+  reader.skip();
+
   return {
     type: "VectorLiteral",
     members,

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -269,7 +269,6 @@ const readRecordPattern = (reader, srcloc) => {
     }
 
     tok = reader.peek();
-    reader.expect(TokenTypes.Symbol, tok.type);
     properties.push(readExpr(reader));
     lastTok = tok;
     tok = reader.peek();

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -125,7 +125,24 @@ const readList = (reader) => {
  * @param {Reader} reader
  * @returns {VectorLiteral}
  */
-const readVector = (reader) => {};
+const readVector = (reader) => {
+  // Get srcloc info from opening bracket and skip it
+  let tok = reader.next();
+  const srcloc = tok.srcloc;
+  tok = reader.peek();
+  let members = [];
+
+  while (tok.type !== TokenTypes.RBrack) {
+    members.push(readExpr(reader));
+    tok = reader.peek();
+  }
+
+  return {
+    kind: "VectorLiteral",
+    members,
+    srcloc,
+  };
+};
 
 /**
  * Reads either a record literal or a record pattern
@@ -137,11 +154,7 @@ const readMaybeRecord = (reader) => {
   const srcloc = tok.srcloc;
   // First token after brace should always be a symbol
   tok = reader.peek();
-
-  if (tok.type !== TokenTypes.Symbol) {
-    throw new SyntaxException(tok.value, tok.srcloc);
-  }
-
+  reader.expect(TokenTypes.Symbol, tok.type);
   tok = reader.lookahead(1);
 
   if (tok.type === TokenTypes.Keyword && tok.value === ":") {

--- a/src/runtime/conversion.js
+++ b/src/runtime/conversion.js
@@ -1,0 +1,23 @@
+import { makeObject } from "./object.js";
+
+/**
+ * Converts a JS value into a Wanda value
+ * @param {any} val
+ * @returns {any}
+ */
+export const makeWandaValue = (val) => {
+  switch (typeof val) {
+    case "object":
+      if (Array.isArray(val)) {
+        return val;
+      }
+
+      if (val.constructor?.name === "Cons") {
+        return val;
+      }
+
+      return makeObject(val);
+    default:
+      return val;
+  }
+};

--- a/src/runtime/conversion.js
+++ b/src/runtime/conversion.js
@@ -1,4 +1,5 @@
-import { hasDict, makeObject } from "./object.js";
+import { makeFunction } from "./makeFunction.js";
+import { hasDict, hasMetaField, makeObject } from "./object.js";
 import { makeKeyword } from "./utils.js";
 
 /**
@@ -8,6 +9,10 @@ import { makeKeyword } from "./utils.js";
  */
 export const makeWandaValue = (val) => {
   switch (typeof val) {
+    case "function":
+      if (!hasMetaField(val, "wanda")) {
+        return makeFunction(val);
+      }
     case "object":
       if (Array.isArray(val)) {
         return val;

--- a/src/runtime/conversion.js
+++ b/src/runtime/conversion.js
@@ -9,11 +9,17 @@ import { makeKeyword } from "./utils.js";
  */
 export const makeWandaValue = (val) => {
   switch (typeof val) {
+    case "undefined":
+      return null;
     case "function":
       if (!hasMetaField(val, "wanda")) {
         return makeFunction(val);
       }
     case "object":
+      if (val === null) {
+        return null;
+      }
+
       if (Array.isArray(val)) {
         return val;
       }
@@ -29,6 +35,10 @@ export const makeWandaValue = (val) => {
 };
 
 export const makeJSValue = (val) => {
+  if (val === null) {
+    return null;
+  }
+
   switch (typeof val) {
     case "object":
       if (hasDict(val)) {

--- a/src/runtime/conversion.js
+++ b/src/runtime/conversion.js
@@ -1,4 +1,5 @@
-import { makeObject } from "./object.js";
+import { hasDict, makeObject } from "./object.js";
+import { makeKeyword } from "./utils.js";
 
 /**
  * Converts a JS value into a Wanda value
@@ -17,6 +18,17 @@ export const makeWandaValue = (val) => {
       }
 
       return makeObject(val);
+    default:
+      return val;
+  }
+};
+
+export const makeJSValue = (val) => {
+  switch (typeof val) {
+    case "object":
+      if (hasDict(val)) {
+        return val[makeKeyword("dict")];
+      }
     default:
       return val;
   }

--- a/src/runtime/makeFunction.js
+++ b/src/runtime/makeFunction.js
@@ -1,1 +1,9 @@
-export const makeFunction = (func) => func;
+import { makeWandaValue } from "./conversion.js";
+import { addMetaField } from "./object.js";
+
+export const makeFunction = (func) => {
+  const fn = (...args) => makeWandaValue(func(...args));
+  addMetaField(fn, "wanda", true);
+
+  return fn;
+};

--- a/src/runtime/makeRuntime.js
+++ b/src/runtime/makeRuntime.js
@@ -4,6 +4,7 @@ import * as utils from "./utils.js";
 import * as obj from "./object.js";
 import { makeSymbol } from "./makeSymbol.js";
 import { makeWandaValue, makeJSValue } from "./conversion.js";
+import { makeNumber } from "./number.js";
 
 /**
  * @typedef Runtime
@@ -23,6 +24,7 @@ import { makeWandaValue, makeJSValue } from "./conversion.js";
  * @prop {Function} getMetaField
  * @prop {Function} addMetaField
  * @prop {Function} makeObject
+ * @prop {Function} makeNumber
  * @prop {Function} failRuntime
  * @prop {Function} fail
  */
@@ -39,5 +41,6 @@ export const makeRuntime = () => {
     makeWandaValue,
     makeJSValue,
     fail,
+    makeNumber,
   };
 };

--- a/src/runtime/makeRuntime.js
+++ b/src/runtime/makeRuntime.js
@@ -3,13 +3,14 @@ import { makeFunction } from "./makeFunction.js";
 import * as utils from "./utils.js";
 import * as obj from "./object.js";
 import { makeSymbol } from "./makeSymbol.js";
-import { makeWandaValue } from "./conversion.js";
+import { makeWandaValue, makeJSValue } from "./conversion.js";
 
 /**
  * @typedef Runtime
  * @prop {Function} makeFunction
  * @prop {Function} makeSymbol
  * @prop {Function} makeWandaValue
+ * @prop {Function} makeJSValue
  * @prop {Function} isNil
  * @prop {Function} isFalsy
  * @prop {Function} isTruthy
@@ -36,6 +37,7 @@ export const makeRuntime = () => {
     ...obj,
     makeSymbol,
     makeWandaValue,
+    makeJSValue,
     fail,
   };
 };

--- a/src/runtime/makeRuntime.js
+++ b/src/runtime/makeRuntime.js
@@ -1,3 +1,4 @@
+import { fail } from "../shared/fail.js";
 import { makeFunction } from "./makeFunction.js";
 import * as utils from "./utils.js";
 import * as obj from "./object.js";
@@ -22,6 +23,7 @@ import { makeWandaValue } from "./conversion.js";
  * @prop {Function} addMetaField
  * @prop {Function} makeObject
  * @prop {Function} failRuntime
+ * @prop {Function} fail
  */
 /**
  * Creates a Wanda runtime
@@ -34,5 +36,6 @@ export const makeRuntime = () => {
     ...obj,
     makeSymbol,
     makeWandaValue,
+    fail,
   };
 };

--- a/src/runtime/makeRuntime.js
+++ b/src/runtime/makeRuntime.js
@@ -2,6 +2,7 @@ import { makeFunction } from "./makeFunction.js";
 import * as utils from "./utils.js";
 import * as obj from "./object.js";
 import { makeSymbol } from "./makeSymbol.js";
+import { makeWandaValue } from "./conversion.js";
 
 /**
  * @typedef Runtime
@@ -17,5 +18,6 @@ export const makeRuntime = () => {
     makeFunction,
     ...obj,
     makeSymbol,
+    makeWandaValue,
   };
 };

--- a/src/runtime/makeRuntime.js
+++ b/src/runtime/makeRuntime.js
@@ -1,5 +1,7 @@
 import { makeFunction } from "./makeFunction.js";
-import { isNil, isTruthy, isFalsy } from "./utils.js";
+import * as utils from "./utils.js";
+import * as obj from "./object.js";
+import { makeSymbol } from "./makeSymbol.js";
 
 /**
  * @typedef Runtime
@@ -11,9 +13,9 @@ import { isNil, isTruthy, isFalsy } from "./utils.js";
  */
 export const makeRuntime = () => {
   return {
-    isFalsy,
-    isNil,
-    isTruthy,
+    ...utils,
     makeFunction,
+    ...obj,
+    makeSymbol,
   };
 };

--- a/src/runtime/makeRuntime.js
+++ b/src/runtime/makeRuntime.js
@@ -2,7 +2,7 @@ import { fail } from "../shared/fail.js";
 import { makeFunction } from "./makeFunction.js";
 import * as utils from "./utils.js";
 import * as obj from "./object.js";
-import { makeSymbol } from "./makeSymbol.js";
+import { makeSymbol, makeGenSym } from "./makeSymbol.js";
 import { makeWandaValue, makeJSValue } from "./conversion.js";
 import { makeNumber } from "./number.js";
 
@@ -10,6 +10,7 @@ import { makeNumber } from "./number.js";
  * @typedef Runtime
  * @prop {Function} makeFunction
  * @prop {Function} makeSymbol
+ * @prop {Function} makeGenSym
  * @prop {Function} makeWandaValue
  * @prop {Function} makeJSValue
  * @prop {Function} isNil
@@ -38,6 +39,7 @@ export const makeRuntime = () => {
     makeFunction,
     ...obj,
     makeSymbol,
+    makeGenSym,
     makeWandaValue,
     makeJSValue,
     fail,

--- a/src/runtime/makeRuntime.js
+++ b/src/runtime/makeRuntime.js
@@ -7,6 +7,21 @@ import { makeWandaValue } from "./conversion.js";
 /**
  * @typedef Runtime
  * @prop {Function} makeFunction
+ * @prop {Function} makeSymbol
+ * @prop {Function} makeWandaValue
+ * @prop {Function} isNil
+ * @prop {Function} isFalsy
+ * @prop {Function} isTruthy
+ * @prop {Function} makeKeyword
+ * @prop {Function} hasDict
+ * @prop {Function} hasField
+ * @prop {Function} hasMethod
+ * @prop {Function} getField
+ * @prop {Function} hasMetaField
+ * @prop {Function} getMetaField
+ * @prop {Function} addMetaField
+ * @prop {Function} makeObject
+ * @prop {Function} failRuntime
  */
 /**
  * Creates a Wanda runtime

--- a/src/runtime/makeSymbol.js
+++ b/src/runtime/makeSymbol.js
@@ -1,4 +1,5 @@
 import objectHash from "object-hash";
+import { createId } from "@paralleldrive/cuid2";
 
 export const PREFIX = "$W_";
 
@@ -8,3 +9,9 @@ export const PREFIX = "$W_";
  * @returns {string}
  */
 export const makeSymbol = (str) => PREFIX + objectHash(str);
+
+/**
+ * Generates a random valid JavaScript identifier
+ * @returns {string}
+ */
+export const makeGenSym = () => PREFIX + createId();

--- a/src/runtime/number.js
+++ b/src/runtime/number.js
@@ -1,0 +1,6 @@
+/**
+ * Parses a number from a string
+ * @param {string} str
+ * @returns {number}
+ */
+export const makeNumber = (str) => Number(str);

--- a/src/runtime/object.js
+++ b/src/runtime/object.js
@@ -118,7 +118,18 @@ export const addMetaField = (obj, field, value) => {
  */
 export const makeObject = (obj) => {
   let newObj = {};
-  addMetaField(newObj, DICT, obj);
+  addMetaField(newObj, "dict", obj);
+  addMetaField(newObj, "constructor", function (...args) {
+    return new obj.constructor(...args);
+  });
+
+  Object.defineProperty(newObj[makeKeyword("constructor")], "name", {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: obj.constructor?.name ?? "WandaObject",
+  });
+
   return newObj;
 };
 

--- a/src/runtime/object.js
+++ b/src/runtime/object.js
@@ -131,6 +131,7 @@ export const makeObject = (obj) => {
     value: obj.constructor?.name ?? "WandaObject",
   });
 
+  // to allow destructuring
   for (let [k, v] of Object.entries(obj)) {
     newObj[makeSymbol(k)] = v;
   }

--- a/src/runtime/object.js
+++ b/src/runtime/object.js
@@ -1,0 +1,132 @@
+import { RuntimeException } from "../shared/exceptions.js";
+import { hasProperty, hasMethod as hM } from "../shared/utils.js";
+import { makeKeyword } from "./utils.js";
+
+const DICT = makeKeyword("dict");
+
+/**
+ * Checks if object has :dict property (i.e. is Wanda object)
+ * @param {Object} obj
+ * @returns {boolean}
+ */
+export const hasDict = (obj) => hasProperty(obj, DICT);
+
+/**
+ * Checks if an object has a field
+ * @param {Object} obj
+ * @param {string|symbol} field
+ * @returns {boolean}
+ */
+export const hasField = (obj, field) => {
+  if (hasDict(obj)) {
+    return hasProperty(obj[DICT], field);
+  }
+
+  return hasProperty(obj[field]);
+};
+
+/**
+ * Checks if an object has a method
+ * @param {Object} obj
+ * @param {string|symbol} method
+ * @returns {boolean}
+ */
+export const hasMethod = (obj, method) => {
+  if (hasDict(obj)) {
+    return hM(obj[DICT], method);
+  }
+
+  return hM(obj, method);
+};
+
+/**
+ * Returns the value of field on obj or obj[:dict]
+ * @param {Object} obj
+ * @param {string|symbol} field
+ * @returns {any}
+ */
+export const getField = (obj, field) => {
+  const value = hasDict(obj) ? obj[DICT][field] : obj?.[field];
+
+  if (value === undefined) {
+    failRuntime(
+      `Field ${
+        typeof field === "symbol" ? field.description : field
+      } not found on object`
+    );
+  }
+
+  if (typeof value === "function") {
+    return hasDict(obj) ? value.bind(obj[DICT]) : value.bind(obj);
+  }
+
+  return value;
+};
+
+/**
+ * Checks if obj has metafield :{field}
+ * @param {Object} obj
+ * @param {string} field
+ * @returns {boolean}
+ */
+export const hasMetaField = (obj, field) => {
+  const kw = makeKeyword(field);
+  return hasProperty(obj[kw]);
+};
+
+/**
+ * Gets value of metafield
+ * @param {Object} obj
+ * @param {string} field
+ * @returns {any}
+ */
+export const getMetaField = (obj, field) => {
+  const kw = makeKeyword(field);
+  const value = obj[kw];
+
+  if (value === undefined) {
+    failRuntime(
+      `Field ${
+        typeof field === "symbol" ? field.description : field
+      } not found on object`
+    );
+  }
+
+  return value;
+};
+
+/**
+ * Adds a metafield to an object
+ * @param {Object} obj
+ * @param {string} field
+ * @param {any} value
+ */
+export const addMetaField = (obj, field, value) => {
+  const meta = makeKeyword(field);
+  Object.defineProperty(obj, meta, {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value,
+  });
+};
+
+/**
+ * Converts a JS object into a Wanda object
+ * @param {Object} obj
+ * @returns {Object}
+ */
+export const makeObject = (obj) => {
+  let newObj = {};
+  addMetaField(newObj, DICT, obj);
+  return newObj;
+};
+
+/**
+ * Throws a RuntimeException
+ * @param {string} msg
+ * @returns {never}
+ */
+export const failRuntime = (msg) => {
+  throw new RuntimeException(msg);
+};

--- a/src/runtime/object.js
+++ b/src/runtime/object.js
@@ -1,5 +1,6 @@
 import { RuntimeException } from "../shared/exceptions.js";
 import { hasProperty, hasMethod as hM } from "../shared/utils.js";
+import { makeSymbol } from "./makeSymbol.js";
 import { makeKeyword } from "./utils.js";
 
 const DICT = makeKeyword("dict");
@@ -129,6 +130,10 @@ export const makeObject = (obj) => {
     writable: false,
     value: obj.constructor?.name ?? "WandaObject",
   });
+
+  for (let [k, v] of Object.entries(obj)) {
+    newObj[makeSymbol(k)] = v;
+  }
 
   return newObj;
 };

--- a/src/runtime/utils.js
+++ b/src/runtime/utils.js
@@ -1,16 +1,10 @@
-/**
- * Checks if a value is nil
- * @param {any} val
- * @returns {boolean}
- */
-export const isNil = (val) => val == null;
-
+import { isNullish } from "../shared/utils.js";
 /**
  * Checks if a value is falsy (false or nil)
  * @param {any} val
  * @returns {boolean}
  */
-export const isFalsy = (val) => val === false || isNil(val);
+export const isFalsy = (val) => val === false || isNullish(val);
 
 /**
  * Checks if a value is truthy (not false or nil)

--- a/src/runtime/utils.js
+++ b/src/runtime/utils.js
@@ -18,3 +18,10 @@ export const isFalsy = (val) => val === false || isNil(val);
  * @returns {boolean}
  */
 export const isTruthy = (val) => !isFalsy(val);
+
+/**
+ * Makes a string into a Wanda keyword
+ * @param {string} str
+ * @returns {symbol}
+ */
+export const makeKeyword = (str) => Symbol.for(`:${str}`);

--- a/src/shared/cons.js
+++ b/src/shared/cons.js
@@ -108,6 +108,10 @@ export class Cons extends Array {
     return undefined;
   }
 
+  toArray() {
+    return [...this];
+  }
+
   *[Symbol.iterator]() {
     let value = this.car;
     let tail = this.cdr;

--- a/src/shared/cons.js
+++ b/src/shared/cons.js
@@ -22,6 +22,10 @@ export class Cons extends Array {
    * @returns {Cons}
    */
   static of(first, ...args) {
+    if (first === undefined) {
+      return null;
+    }
+
     let list = cons(first, null);
 
     for (let arg of args) {

--- a/src/shared/cons.js
+++ b/src/shared/cons.js
@@ -36,6 +36,15 @@ export class Cons extends Array {
   }
 
   /**
+   * Converts an iterable to a list
+   * @param {Array} iter
+   * @returns {Cons}
+   */
+  static from(iter) {
+    return Cons.of(...iter);
+  }
+
+  /**
    * Get the head of the Cons cell
    */
   get car() {

--- a/src/shared/exceptions.js
+++ b/src/shared/exceptions.js
@@ -53,10 +53,13 @@ export class SyntaxException extends Exception {
    * Constructs a SyntaxException
    * @param {string} value
    * @param {SrcLoc} srcloc
+   * @param {string} [expected=""]
    */
-  constructor(value, srcloc) {
+  constructor(value, srcloc, expected = "") {
     super(
-      `Syntax Exception: invalid syntax ${value} found at ${srcloc.file} (${srcloc.line}:${srcloc.col})`
+      `Syntax Exception: invalid syntax ${value}${
+        expected ? ` (expected ${expected})` : ""
+      } found at ${srcloc.file} (${srcloc.line}:${srcloc.col})`
     );
   }
 }

--- a/src/shared/exceptions.js
+++ b/src/shared/exceptions.js
@@ -50,7 +50,7 @@ export class Exception extends Error {
  */
 export class SyntaxException extends Exception {
   /**
-   *
+   * Constructs a SyntaxException
    * @param {string} value
    * @param {SrcLoc} srcloc
    */
@@ -58,5 +58,20 @@ export class SyntaxException extends Exception {
     super(
       `Syntax Exception: invalid syntax ${value} found at ${srcloc.file} (${srcloc.line}:${srcloc.col})`
     );
+  }
+}
+
+/**
+ * @class
+ * @desc Type errors found during type checking
+ */
+export class TypeException extends Exception {
+  /**
+   * Constructs a TypeException
+   * @param {string} msg
+   * @param {SrcLoc} srcloc
+   */
+  constructor(msg, srcloc) {
+    super(`${msg} at ${srcloc.file} ${srcloc.line}:${srcloc.col}`);
   }
 }

--- a/src/shared/exceptions.js
+++ b/src/shared/exceptions.js
@@ -102,13 +102,4 @@ export class RuntimeException extends Exception {
     super(msg);
     this[Symbol.for(":dict")] = { message: msg };
   }
-
-  /**
-   * Static constructor
-   * @param {string} msg
-   * @returns {RuntimeException}
-   */
-  static new(msg) {
-    return new RuntimeException(msg);
-  }
 }

--- a/src/shared/exceptions.js
+++ b/src/shared/exceptions.js
@@ -1,8 +1,7 @@
 import { SrcLoc } from "../lexer/SrcLoc.js";
 
 /**
- * @class
- * @desc Base error class for Wanda
+ * Base error class for Wanda
  * @prop {string} msg
  * @prop {string[]} stack
  */
@@ -45,8 +44,7 @@ export class Exception extends Error {
 }
 
 /**
- * @class
- * @desc Syntax errors found during lexing, reading, and parsing
+ * Syntax errors found during lexing, reading, and parsing
  */
 export class SyntaxException extends Exception {
   /**
@@ -65,8 +63,7 @@ export class SyntaxException extends Exception {
 }
 
 /**
- * @class
- * @desc Type errors found during type checking
+ * Type errors found during type checking
  */
 export class TypeException extends Exception {
   /**
@@ -80,8 +77,7 @@ export class TypeException extends Exception {
 }
 
 /**
- * @class
- * @desc Reference errors found during compilation
+ *  Reference errors found during compilation
  */
 export class ReferenceException extends Exception {
   /**
@@ -91,5 +87,28 @@ export class ReferenceException extends Exception {
    */
   constructor(msg, srcloc) {
     super(`${msg} at ${srcloc.file} ${srcloc.line}:${srcloc.col}`);
+  }
+}
+
+/**
+ * Errors found during runtime
+ */
+export class RuntimeException extends Exception {
+  /**
+   * Constructs a RuntimeException
+   * @param {string} msg
+   */
+  constructor(msg) {
+    super(msg);
+    this[Symbol.for(":dict")] = { message: msg };
+  }
+
+  /**
+   * Static constructor
+   * @param {string} msg
+   * @returns {RuntimeException}
+   */
+  static new(msg) {
+    return new RuntimeException(msg);
   }
 }

--- a/src/shared/exceptions.js
+++ b/src/shared/exceptions.js
@@ -75,3 +75,18 @@ export class TypeException extends Exception {
     super(`${msg} at ${srcloc.file} ${srcloc.line}:${srcloc.col}`);
   }
 }
+
+/**
+ * @class
+ * @desc Reference errors found during compilation
+ */
+export class ReferenceException extends Exception {
+  /**
+   * Constructs a ReferenceException
+   * @param {string} msg
+   * @param {SrcLoc} srcloc
+   */
+  constructor(msg, srcloc) {
+    super(`${msg} at ${srcloc.file} ${srcloc.line}:${srcloc.col}`);
+  }
+}

--- a/src/shared/exceptions.js
+++ b/src/shared/exceptions.js
@@ -13,7 +13,7 @@ export class Exception extends Error {
    */
   constructor(msg, stack = []) {
     super(msg);
-    this.stack = stack;
+    this.wandaStack = stack;
   }
 
   /**
@@ -21,7 +21,7 @@ export class Exception extends Error {
    * @param {string} frame
    */
   appendStack(frame) {
-    this.stack.push(frame);
+    this.wandaStack.push(frame);
   }
 
   /**
@@ -29,7 +29,7 @@ export class Exception extends Error {
    * @returns {string}
    */
   dumpStack() {
-    let stack = [...this.stack].reverse();
+    let stack = [...this.wandaStack].reverse();
 
     let dump = "";
 

--- a/src/shared/exceptions.js
+++ b/src/shared/exceptions.js
@@ -57,9 +57,9 @@ export class SyntaxException extends Exception {
    */
   constructor(value, srcloc, expected = "") {
     super(
-      `Syntax Exception: invalid syntax ${value}${
-        expected ? ` (expected ${expected})` : ""
-      } found at ${srcloc.file} (${srcloc.line}:${srcloc.col})`
+      `Syntax Exception: invalid syntax ${value} found at ${srcloc.file} (${
+        srcloc.line
+      }:${srcloc.col})${expected ? ` (expected ${expected})` : ""}`
     );
   }
 }

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -1,0 +1,17 @@
+/**
+ * Checks if null or undefined
+ * @param {any} obj
+ * @returns {boolean}
+ */
+export const isNullish = (obj) => obj != null;
+
+/**
+ * Checks if object has property prop
+ * @param {Object} obj
+ * @param {string} prop
+ * @returns {boolean}
+ */
+export const hasProperty = (obj, prop) => !isNullish(obj?.[prop]);
+
+export const hasMethod = (obj, methodName) =>
+  hasProperty(obj, methodName) && typeof obj[methodName] === "function";

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -8,10 +8,16 @@ export const isNullish = (obj) => obj != null;
 /**
  * Checks if object has property prop
  * @param {Object} obj
- * @param {string} prop
+ * @param {string|symbol} prop
  * @returns {boolean}
  */
 export const hasProperty = (obj, prop) => !isNullish(obj?.[prop]);
 
+/**
+ * Checks if object has method methodName
+ * @param {Object} obj
+ * @param {string|symbol} methodName
+ * @returns {boolean}
+ */
 export const hasMethod = (obj, methodName) =>
   hasProperty(obj, methodName) && typeof obj[methodName] === "function";

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -3,7 +3,7 @@
  * @param {any} obj
  * @returns {boolean}
  */
-export const isNullish = (obj) => obj != null;
+export const isNullish = (obj) => obj == null;
 
 /**
  * Checks if object has property prop

--- a/src/typechecker/Type.js
+++ b/src/typechecker/Type.js
@@ -1,13 +1,11 @@
 import { TypeTypes } from "./types.js";
 import * as Validators from "./validators.js";
 import * as Constructors from "./constructors.js";
-import { fromTypeAnnotation } from "./fromTypeAnnotation.js";
 import { typeToString } from "./typeToString.js";
 
 export const Type = {
   Type: TypeTypes,
   ...Constructors,
   ...Validators,
-  fromTypeAnnotation,
   toString: typeToString,
 };

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -106,11 +106,19 @@ export class TypeChecker {
    * @return {TypedAST}
    */
   checkDoExpression(node, env) {
+    /** @type {TypedAST[]} */
+    let body = [];
     for (let expr of node.body) {
-      this.check(expr, env);
+      const node = this.check(expr, env);
+      body.push(node);
     }
 
-    return { ...node, type: infer(node, env) };
+    return {
+      kind: node.kind,
+      body,
+      srcloc: node.srcloc,
+      type: infer(node, env),
+    };
   }
 
   /**
@@ -154,18 +162,22 @@ export class TypeChecker {
    * @returns {TypedAST}
    */
   checkProgram(node, env) {
+    /** @type {TypedAST[]} */
+    let body = [];
     let type;
     let i = 0;
     for (let expr of node.body) {
       if (i === node.body.length - 1) {
         const node = this.check(expr, env);
         type = node.type;
+        body.push(node);
       } else {
-        this.check(expr, env);
+        const node = this.check(expr, env);
+        body.push(node);
       }
     }
 
-    return { ...node, type };
+    return { kind: node.kind, body, srcloc: node.srcloc, type };
   }
 
   checkRecordLiteral(node, env) {
@@ -192,7 +204,13 @@ export class TypeChecker {
       return { ...node, type: nameType };
     }
 
-    return { ...node, type: infer(node, env) };
+    return {
+      kind: node.kind,
+      lhv: node.lhv,
+      expression: this.check(node.expression, env),
+      srcloc: node.srcloc,
+      type: infer(node, env),
+    };
   }
 
   /**
@@ -301,7 +319,13 @@ export class TypeChecker {
       }
     }
 
-    return { ...node, type };
+    return {
+      kind: node.kind,
+      lhv: node.lhv,
+      expression: this.check(node.expression, env),
+      srcloc: node.srcloc,
+      type,
+    };
   }
 
   /**

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -173,6 +173,13 @@ export class TypeChecker {
    * @returns {TypedAST}
    */
   checkSetExpression(node, env) {
+    if (node.lhv.kind !== ASTTypes.Symbol) {
+      throw new TypeException(
+        `Cannot use destructuring with set! assignment`,
+        node.srcloc
+      );
+    }
+
     if (env.checkingOn) {
       const nameType = env.getType(node.lhv.name);
       check(node.expression, nameType, env);

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -70,7 +70,7 @@ export class TypeChecker {
       case ASTTypes.MemberExpression:
         return this.checkMemberExpression(node, env);
       case ASTTypes.RecordLiteral:
-        return this.checkMemberExpression(node, env);
+        return this.checkRecordLiteral(node, env);
       case ASTTypes.VectorLiteral:
         return this.checkVectorLiteral(node, env);
       default:

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -276,7 +276,7 @@ export class TypeChecker {
           if (node.lhv.rest && i === node.lhv.members.length - 1) {
             env.set(mem.name, type);
           } else {
-            env.set(mem.name, type.vectorType);
+            env.set(mem.name, type.vectorType ? type.vectorType : type.listType);
           }
           i++;
         }

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -115,6 +115,8 @@ export class TypeChecker {
     return { ...node, type: infer(node, env) };
   }
 
+  checkMemberExpression(node, env) {}
+
   /**
    * Type checks a nil literal
    * @param {import("../parser/ast").NilLiteral} node
@@ -155,6 +157,8 @@ export class TypeChecker {
 
     return { ...node, type };
   }
+
+  checkRecordLiteral(node, env) {}
 
   /**
    * Type checks a set expression
@@ -223,4 +227,6 @@ export class TypeChecker {
     env.set(node.lhv.name, type);
     return { ...node, type };
   }
+
+  checkVectorLiteral(node, env) {}
 }

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -3,7 +3,7 @@ import { Exception } from "../shared/exceptions.js";
 import { TypeEnvironment } from "./TypeEnvironment.js";
 import { check } from "./check.js";
 import { infer } from "./infer.js";
-import { Type } from "./Type.js";
+import { fromTypeAnnotation } from "./fromTypeAnnotation.js";
 
 /**
  * @typedef {AST & {type: import("./types").Type}} TypedAST
@@ -199,7 +199,7 @@ export class TypeChecker {
    * @returns {TypedAST}
    */
   checkTypeAlias(node, env) {
-    const type = Type.fromTypeAnnotation(node.type, env);
+    const type = fromTypeAnnotation(node.type, env);
     env.setType(node.name, type);
     return { ...node, type };
   }
@@ -212,7 +212,7 @@ export class TypeChecker {
    */
   checkVariableDeclaration(node, env) {
     if (node.typeAnnotation) {
-      const annotType = Type.fromTypeAnnotation(node.typeAnnotation, env);
+      const annotType = fromTypeAnnotation(node.typeAnnotation, env);
       check(node.expression, annotType, env);
       env.checkingOn = true;
       env.set(node.lhv.name, annotType);

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -67,6 +67,12 @@ export class TypeChecker {
         return this.checkDoExpression(node, env);
       case ASTTypes.TypeAlias:
         return this.checkTypeAlias(node, env);
+      case ASTTypes.MemberExpression:
+        return this.checkMemberExpression(node, env);
+      case ASTTypes.RecordLiteral:
+        return this.checkMemberExpression(node, env);
+      case ASTTypes.VectorLiteral:
+        return this.checkVectorLiteral(node, env);
       default:
         throw new Exception(`Type checking not implemented for ${node.kind}`);
     }

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -115,7 +115,9 @@ export class TypeChecker {
     return { ...node, type: infer(node, env) };
   }
 
-  checkMemberExpression(node, env) {}
+  checkMemberExpression(node, env) {
+    return { ...node, type: infer(node, env) };
+  }
 
   /**
    * Type checks a nil literal
@@ -158,7 +160,9 @@ export class TypeChecker {
     return { ...node, type };
   }
 
-  checkRecordLiteral(node, env) {}
+  checkRecordLiteral(node, env) {
+    return { ...node, type: infer(node, env) };
+  }
 
   /**
    * Type checks a set expression
@@ -228,5 +232,13 @@ export class TypeChecker {
     return { ...node, type };
   }
 
-  checkVectorLiteral(node, env) {}
+  /**
+   * Type checks a vector literal
+   * @param {import("../parser/ast.js").VectorLiteral} node
+   * @param {TypeEnvironment} env
+   * @returns {TypedAST}
+   */
+  checkVectorLiteral(node, env) {
+    return { ...node, type: infer(node, env) };
+  }
 }

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -241,9 +241,9 @@ export class TypeChecker {
     if (node.lhv.kind === ASTTypes.Symbol) {
       env.set(node.lhv.name, type);
     } else if (node.lhv.kind === ASTTypes.VectorPattern) {
-      if (!Type.isVector(type)) {
+      if (!Type.isVector(type) && !Type.isList(type)) {
         throw new TypeException(
-          `Cannot destructure non-vector type with vector pattern`,
+          `Vector pattern destructuring must take a vector or list type`,
           node.srcloc
         );
       } else {

--- a/src/typechecker/check.js
+++ b/src/typechecker/check.js
@@ -16,9 +16,9 @@ export const check = (ast, type, env) => {
 
   if (!isSubtype(inferredType, type)) {
     throw new TypeException(
-      `Type ${Type.toString(inferredType)} is not a subtype of ${Type.toString(
-        type
-      )}`,
+      `Type ${Type.toString(
+        inferredType
+      )} is not a valid subtype of ${Type.toString(type)}`,
       ast.srcloc
     );
   }

--- a/src/typechecker/check.js
+++ b/src/typechecker/check.js
@@ -1,9 +1,10 @@
-import { AST } from "../parser/ast.js";
+import { AST, ASTTypes } from "../parser/ast.js";
 import { TypeException } from "../shared/exceptions.js";
 import { Type } from "./Type.js";
 import { TypeEnvironment } from "./TypeEnvironment.js";
 import { infer } from "./infer.js";
 import { isSubtype } from "./isSubtype.js";
+import { propType } from "./propType.js";
 
 /**
  * Checks to see if the type of AST matches type
@@ -12,6 +13,10 @@ import { isSubtype } from "./isSubtype.js";
  * @param {TypeEnvironment} env
  */
 export const check = (ast, type, env) => {
+  if (ast.kind === ASTTypes.RecordLiteral && Type.isObject(type)) {
+    return checkObject(ast, type, env);
+  }
+
   const inferredType = infer(ast, env);
 
   if (!isSubtype(inferredType, type)) {
@@ -22,4 +27,41 @@ export const check = (ast, type, env) => {
       ast.srcloc
     );
   }
+};
+
+/**
+ *
+ * @param {import("../parser/ast.js").RecordLiteral} ast
+ * @param {import("./types").Object} type
+ * @param {TypeEnvironment} env
+ */
+const checkObject = (ast, type, env) => {
+  const astProps = ast.properties.map((prop) => ({
+    name: prop.key.name,
+    expr: prop.value,
+  }));
+
+  type.properties.forEach(({ name }) => {
+    const astProp = astProps.find(({ name: astName }) => astName === name);
+
+    if (!astProp) {
+      throw new TypeException(
+        `Property ${name} not found on record literal`,
+        ast.srcloc
+      );
+    }
+  });
+
+  astProps.forEach(({ name, expr }) => {
+    const pType = propType(type, name);
+
+    if (!pType) {
+      throw new TypeException(
+        `Property ${name} not found on object of type ${Type.toString(type)}`,
+        ast.srcloc
+      );
+    }
+
+    check(expr, pType, env);
+  });
 };

--- a/src/typechecker/check.js
+++ b/src/typechecker/check.js
@@ -1,5 +1,5 @@
 import { AST } from "../parser/ast.js";
-import { Exception } from "../shared/exceptions.js";
+import { TypeException } from "../shared/exceptions.js";
 import { Type } from "./Type.js";
 import { TypeEnvironment } from "./TypeEnvironment.js";
 import { infer } from "./infer.js";
@@ -15,10 +15,11 @@ export const check = (ast, type, env) => {
   const inferredType = infer(ast, env);
 
   if (!isSubtype(inferredType, type)) {
-    throw new Exception(
+    throw new TypeException(
       `Type ${Type.toString(inferredType)} is not a subtype of ${Type.toString(
         type
-      )} at ${ast.srcloc.file} ${ast.srcloc.line}:${ast.srcloc.col}`
+      )}`,
+      ast.srcloc
     );
   }
 };

--- a/src/typechecker/constructors.js
+++ b/src/typechecker/constructors.js
@@ -57,4 +57,21 @@ export const typeAlias = (name, base) => ({
  * @param {import("./types").Type} listType
  * @returns {import("./types").List}
  */
-export const listType = (listType) => ({ kind: TypeTypes.List, listType });
+export const list = (listType) => ({ kind: TypeTypes.List, listType });
+
+/**
+ * Vector type constructor
+ * @param {import("./types.js").Type} vectorType
+ * @returns {import("./types.js").Vector}
+ */
+export const vector = (vectorType) => ({
+  kind: TypeTypes.Vector,
+  vectorType,
+});
+
+/**
+ * Object type constructor
+ * @param {import("./types.js").Property[]} properties
+ * @returns {import("./types.js").Object}
+ */
+export const object = (properties) => ({ kind: TypeTypes.Object, properties });

--- a/src/typechecker/fromTypeAnnotation.js
+++ b/src/typechecker/fromTypeAnnotation.js
@@ -48,7 +48,7 @@ export const fromTypeAnnotation = (
     case TATypes.Object: {
       const propTypes = typeAnnotation.properties.map((prop) => ({
         name: prop.name,
-        type: fromTypeAnnotation(prop.type, typeEnv),
+        type: fromTypeAnnotation(prop.propType, typeEnv),
       }));
       return Type.object(propTypes);
     }

--- a/src/typechecker/fromTypeAnnotation.js
+++ b/src/typechecker/fromTypeAnnotation.js
@@ -15,6 +15,8 @@ export const fromTypeAnnotation = (
   typeEnv = TypeEnvironment.new()
 ) => {
   switch (typeAnnotation.kind) {
+    case TATypes.AnyLiteral:
+      return Type.any;
     case TATypes.NumberLiteral:
       return Type.number;
     case TATypes.StringLiteral:

--- a/src/typechecker/fromTypeAnnotation.js
+++ b/src/typechecker/fromTypeAnnotation.js
@@ -10,7 +10,10 @@ import { Exception } from "../shared/exceptions.js";
  * @returns {import("./types.js").Type}
  */
 
-export const fromTypeAnnotation = (typeAnnotation, typeEnv) => {
+export const fromTypeAnnotation = (
+  typeAnnotation,
+  typeEnv = TypeEnvironment.new()
+) => {
   switch (typeAnnotation.kind) {
     case TATypes.NumberLiteral:
       return Type.number;

--- a/src/typechecker/fromTypeAnnotation.js
+++ b/src/typechecker/fromTypeAnnotation.js
@@ -38,6 +38,17 @@ export const fromTypeAnnotation = (typeAnnotation, typeEnv) => {
       const listType = fromTypeAnnotation(typeAnnotation.listType, typeEnv);
       return Type.list(listType);
     }
+    case TATypes.Vector: {
+      const vectorType = fromTypeAnnotation(typeAnnotation.vectorType, typeEnv);
+      return Type.vector(vectorType);
+    }
+    case TATypes.Object: {
+      const propTypes = typeAnnotation.properties.map((prop) => ({
+        name: prop.name,
+        type: fromTypeAnnotation(prop.type, typeEnv),
+      }));
+      return Type.object(propTypes);
+    }
     default:
       throw new Exception(
         `Type not found for type annotation ${JSON.parse(

--- a/src/typechecker/fromTypeAnnotation.js
+++ b/src/typechecker/fromTypeAnnotation.js
@@ -36,7 +36,7 @@ export const fromTypeAnnotation = (typeAnnotation, typeEnv) => {
     }
     case TATypes.List: {
       const listType = fromTypeAnnotation(typeAnnotation.listType, typeEnv);
-      return Type.listType(listType);
+      return Type.list(listType);
     }
     default:
       throw new Exception(

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -4,6 +4,7 @@ import { Type } from "./Type.js";
 import { TypeEnvironment } from "./TypeEnvironment.js";
 import { isSubtype } from "./isSubtype.js";
 import { getAliasBase } from "./utils.js";
+import { fromTypeAnnotation } from "./fromTypeAnnotation.js";
 
 /**
  * Infers a type from an AST node
@@ -169,5 +170,5 @@ const inferDoExpression = (node, env) => {
  * @returns {import("./types").Type}
  */
 const inferTypeAlias = (node, env) => {
-  return Type.fromTypeAnnotation(node.type, env);
+  return fromTypeAnnotation(node.type, env);
 };

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -42,6 +42,8 @@ export const infer = (ast, env) => {
       return inferVectorLiteral(ast, env);
     case ASTTypes.RecordLiteral:
       return inferRecordLiteral(ast, env);
+    case ASTTypes.MemberExpression:
+      return inferMemberExpression(ast, env);
     default:
       throw new Exception(`No type inferred for AST node type ${ast.kind}`);
   }

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -234,15 +234,19 @@ const inferMemberExpression = (node, env) => {
   const object = infer(node.object, env);
 
   if (!Type.isObject(object)) {
-    throw new TypeException(
-      `Member expression expects object type; ${Type.toString(object)} given`,
-      node.srcloc
-    );
+    if (env.checkingOn) {
+      throw new TypeException(
+        `Member expression expects object type; ${Type.toString(object)} given`,
+        node.srcloc
+      );
+    } else {
+      return Type.any;
+    }
   }
 
   const type = propType(object, prop.name);
 
-  if (!type) {
+  if (!type && env.checkingOn) {
     throw new TypeException(
       `Property ${prop.name} not found on object of type ${Type.toString(
         object
@@ -251,5 +255,5 @@ const inferMemberExpression = (node, env) => {
     );
   }
 
-  return type;
+  return type ?? Type.any;
 };

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -205,7 +205,7 @@ const inferVectorLiteral = (node, env) => {
     return Type.any;
   }
 
-  return unified;
+  return Type.vector(unified);
 };
 
 /**

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -39,6 +39,8 @@ export const infer = (ast, env) => {
       return inferTypeAlias(ast, env);
     case ASTTypes.VectorLiteral:
       return inferVectorLiteral(ast, env);
+    case ASTTypes.RecordLiteral:
+      return inferRecordLiteral(ast, env);
     default:
       throw new Exception(`No type inferred for AST node type ${ast.kind}`);
   }
@@ -180,6 +182,7 @@ const inferTypeAlias = (node, env) => {
  * Infer the type of a VectorLiteral node
  * @param {import("../parser/ast.js").VectorLiteral} node
  * @param {TypeEnvironment} env
+ * @returns {import("./types").Vector}
  */
 const inferVectorLiteral = (node, env) => {
   if (node.members.length === 0) {
@@ -200,4 +203,19 @@ const inferVectorLiteral = (node, env) => {
   }
 
   return unified;
+};
+
+/**
+ * Infer the type of a RecordLiteral node
+ * @param {import("../parser/ast.js").RecordLiteral} node
+ * @param {TypeEnvironment} env
+ * @returns {import("./types").Object}
+ */
+const inferRecordLiteral = (node, env) => {
+  const properties = node.properties.map((prop) => ({
+    kind: Type.Type.Property,
+    name: prop.key.name,
+    type: infer(prop.value, env),
+  }));
+  return Type.object(properties);
 };

--- a/src/typechecker/isSubtype.js
+++ b/src/typechecker/isSubtype.js
@@ -1,4 +1,5 @@
 import { Type } from "./Type.js";
+import { propType } from "./propType.js";
 
 /**
  * Checks if type1 is a subtype of type2
@@ -28,6 +29,18 @@ export const isSubtype = (type1, type2) => {
 
   if (Type.isList(type1) && Type.isList(type2)) {
     return isSubtype(type1.listType, type2.listType);
+  }
+
+  if (Type.isVector(type1) && Type.isVector(type2)) {
+    return isSubtype(type1.vectorType, type2.vectorType);
+  }
+
+  if (Type.isObject(type1) && Type.isObject(type2)) {
+    return type2.properties.every(({ name: type2name, type: type2type }) => {
+      const type1type = propType(type1, type2name);
+      if (!type1type) return false;
+      else return isSubtype(type1type, type2type);
+    });
   }
 
   return false;

--- a/src/typechecker/propType.js
+++ b/src/typechecker/propType.js
@@ -1,0 +1,7 @@
+/**
+ * Gets the type of an object property if it exists
+ * @param {import("./types").Object} type
+ * @param {string} name
+ * @returns {import("./types").Type|null}
+ */
+export const propType = (type, name) => {};

--- a/src/typechecker/propType.js
+++ b/src/typechecker/propType.js
@@ -4,4 +4,7 @@
  * @param {string} name
  * @returns {import("./types").Type|null}
  */
-export const propType = (type, name) => {};
+export const propType = (type, name) => {
+  const prop = type.properties.find(({ name: propName }) => propName === name);
+  return prop ? prop.type : null;
+};

--- a/src/typechecker/typeToString.js
+++ b/src/typechecker/typeToString.js
@@ -28,6 +28,12 @@ export const typeToString = (type) => {
       return `TypeAlias: ${type.name}, base: ${typeToString(type.base)}`;
     case TypeTypes.List:
       return `list (${typeToString(type.listType)})`;
+    case TypeTypes.Vector:
+      return `vector (${typeToString(type.vectorType)})`;
+    case TypeTypes.Object:
+      return `{ ${type.properties
+        .map((p) => `${p.name} : ${typeToString(p.type)}`)
+        .join(", ")} }`;
     default:
       throw new Exception(`String conversion not implemented for ${type.kind}`);
   }

--- a/src/typechecker/types.js
+++ b/src/typechecker/types.js
@@ -11,6 +11,9 @@ export const TypeTypes = {
   FunctionType: "FunctionType",
   TypeAlias: "TypeAlias",
   List: "List",
+  Vector: "Vector",
+  Property: "Property",
+  Object: "Object",
 };
 /**
  * @typedef Any
@@ -55,8 +58,24 @@ export const TypeTypes = {
  * @prop {Type} listType
  */
 /**
+ * @typedef Vector
+ * @prop {TypeTypes.Vector} kind
+ * @prop {Type} vectorType
+ */
+/**
+ * @typedef Property
+ * @prop {TypeTypes.Property} kind
+ * @prop {string} name
+ * @prop {Type} type
+ */
+/**
+ * @typedef Object
+ * @prop {TypeTypes.Object} kind
+ * @prop {Property[]} properties
+ */
+/**
  * @typedef {Number|String|Boolean|Keyword|Nil} PrimitiveTypes
  */
 /**
- * @typedef {Any|PrimitiveTypes|FunctionType|TypeAlias|List} Type
+ * @typedef {Any|PrimitiveTypes|FunctionType|TypeAlias|List|Vector|Object} Type
  */

--- a/src/typechecker/unify.js
+++ b/src/typechecker/unify.js
@@ -1,0 +1,32 @@
+import { Type } from "./Type.js";
+import { isSubtype } from "./isSubtype.js";
+
+/**
+ * Unifies types by returning the common supertype
+ * @param {import("./types.js").Type} type1
+ * @param {import("./types.js").Type} type2
+ * @returns {import("./types.js").Type|null}
+ */
+export const unify = (type1, type2) => {
+  if (isSubtype(type1, type2)) {
+    return type2;
+  } else if (isSubtype(type2, type1)) {
+    return type1;
+  }
+
+  return null;
+};
+
+/**
+ * Unifies an arbitrary number of types
+ * @param  {...import("./types.js").Type} types
+ * @returns {import("./types.js").Type|null}
+ */
+export const unifyAll = (...types) => {
+  return types.reduce((unified, type) => {
+    if (unified === null) return null;
+    if (Type.isAny(unified)) return unified;
+
+    return unify(unified, type);
+  });
+};

--- a/src/typechecker/validators.js
+++ b/src/typechecker/validators.js
@@ -89,3 +89,12 @@ export const isList = (type) => {
 export const isVector = (type) => {
   return type.kind === TypeTypes.Vector;
 };
+
+/**
+ * Checks if current type is an object
+ * @param {import("./types.js").Type} type
+ * @returns {boolean}
+ */
+export const isObject = (type) => {
+  return type.kind === TypeTypes.Object;
+};

--- a/src/typechecker/validators.js
+++ b/src/typechecker/validators.js
@@ -80,3 +80,12 @@ export const isTypeAlias = (type) => {
 export const isList = (type) => {
   return type.kind === TypeTypes.List;
 };
+
+/**
+ * Checks if current type is a vector
+ * @param {import("./types").Type} type
+ * @returns {boolean}
+ */
+export const isVector = (type) => {
+  return type.kind === TypeTypes.Vector;
+};

--- a/tests/eval/eval.test.js
+++ b/tests/eval/eval.test.js
@@ -1,6 +1,11 @@
 import vm from "vm";
 import { EVAL } from "../../src/cli/eval.js";
 import { compileAndBuild } from "../../src/cli/compileAndBuild.js";
+import { build } from "../../src/cli/build.js";
+import { emitGlobalEnv } from "../../src/emitter/emitGlobalEnv.js";
+import { compile } from "../../src/cli/compile.js";
+import { makeGlobalTypeEnv } from "../../src/typechecker/makeGlobalTypeEnv.js";
+import { makeGlobalNameMap } from "../../src/runtime/makeGlobals.js";
 
 test("should evaluate an integer properly", () => {
   const input = "15";
@@ -58,10 +63,14 @@ test("should evaluate nested call expressions properly", () => {
   expect(vm.runInThisContext(built)).toEqual(8);
 });
 
-test.skip("should return the value of the last expression in a program", () => {
+test("should return the value of the last expression in a program", () => {
   const input = `(+ 1 2)
 (append "Hello, " "world")`;
-  const built = compileAndBuild(input, { fileName: "test-input" });
+  const globalCode = build(emitGlobalEnv());
+  vm.runInThisContext(globalCode);
+  const globalEnv = makeGlobalNameMap();
+  const typeEnv = makeGlobalTypeEnv();
+  const compiled = compile(input, "test-input", globalEnv, typeEnv);
 
-  expect(vm.runInThisContext(built)).toEqual("Hello, world");
+  expect(vm.runInThisContext(compiled)).toEqual("Hello, world");
 });


### PR DESCRIPTION
Adding vectors and records to the Wanda language, including member expressions and type checking

- Vector and record literals
- Member expressions
- Records are JS objects with a :dict property that holds its members
- Vectors are JS arrays
- Member expressions compile to calls to `rt.getField`
- Toplevel destructuring with rest variables
- No nested destructuring
- No destructuring in set expressions, only variable declarations
- Runtime object available in compiled output