### PR TITLE
Functions

### DIFF
--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -162,6 +162,16 @@ export const theModule = makeModule("Core", (rt, ns) => {
     prop: rt.makeFunction((prop, obj) => rt.getField(obj, prop), {
       contract: "(string, any -> any)",
     }),
+    each: rt.makeFunction(
+      (fn, lst) => {
+        for (let item of lst) {
+          fn(item);
+        }
+      },
+      {
+        contract: "((any -> nil), (list any) -> nil)",
+      }
+    ),
     map: rt.makeFunction(
       (fn, lst) => {
         let mapped = [];

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -21,93 +21,147 @@ export const theModule = makeModule("Core", (rt, ns) => {
 
   return {
     __module__: "Global",
-    print: rt.makeFunction(print),
-    println: rt.makeFunction(println),
-    cons,
-    car: rt.makeFunction((pair) => pair.car),
-    cdr: rt.makeFunction((pair) => pair.cdr),
-    string: rt.makeFunction(printString),
-    number: rt.makeFunction(Number),
-    boolean: rt.makeFunction((val) => isTruthy(val)),
-    symbol: rt.makeFunction((str) => Symbol.for(str)),
-    keyword: rt.makeFunction((str) => Symbol.for(":" + str)),
-    "+": rt.makeFunction((a, b, ...nums) =>
-      nums.reduce((sum, n) => sum + n, a + b)
+    print: rt.makeFunction(print, { contract: "(any -> string)" }),
+    println: rt.makeFunction(println, { contract: "(any -> string)" }),
+    cons: rt.makeFunction(cons, { contract: "(any, any -> (list any))" }),
+    car: rt.makeFunction((pair) => pair.car, {
+      contract: "((list any) -> any)",
+    }),
+    cdr: rt.makeFunction((pair) => pair.cdr, {
+      contract: "((list any) -> any)",
+    }),
+    string: rt.makeFunction(printString, { contract: "(any -> string)" }),
+    number: rt.makeFunction(Number, { contract: "(string -> number)" }),
+    boolean: rt.makeFunction((val) => isTruthy(val), {
+      contract: "(any -> boolean)",
+    }),
+    keyword: rt.makeFunction((str) => Symbol.for(":" + str), {
+      contract: "(string -> keyword)",
+    }),
+    "+": rt.makeFunction(
+      (a, b, ...nums) => nums.reduce((sum, n) => sum + n, a + b),
+      { contract: "(number, number, &(vector number) -> number)" }
     ),
-    "-": rt.makeFunction((a, b, ...nums) =>
-      nums.reduce((diff, n) => diff - n, a - b)
+    "-": rt.makeFunction(
+      (a, b, ...nums) => nums.reduce((diff, n) => diff - n, a - b),
+      { contract: "(number, number, &(vector number) -> number)" }
     ),
-    "*": rt.makeFunction((a, b, ...nums) =>
-      nums.reduce((prod, n) => prod * n, a * b)
+    "*": rt.makeFunction(
+      (a, b, ...nums) => nums.reduce((prod, n) => prod * n, a * b),
+      { contract: "(number, number, &(vector number) -> number)" }
     ),
-    "/": rt.makeFunction((a, b, ...nums) =>
-      nums.reduce((quot, n) => quot / n, a / b)
+    "/": rt.makeFunction(
+      (a, b, ...nums) => nums.reduce((quot, n) => quot / n, a / b),
+      { contract: "(number, number, &(vector number) -> number)" }
     ),
-    "%": rt.makeFunction((a, b, ...nums) =>
-      nums.reduce((quot, n) => quot % n, a % b)
+    "%": rt.makeFunction(
+      (a, b, ...nums) => nums.reduce((quot, n) => quot % n, a % b),
+      { contract: "(number, number, &(vector number) -> number)" }
     ),
-    "=": rt.makeFunction((a, b) => a === b),
-    ">": rt.makeFunction((a, b) => a > b),
-    ">=": rt.makeFunction((a, b) => a >= b),
-    "<": rt.makeFunction((a, b) => a < b),
-    "<=": rt.makeFunction((a, b) => a <= b),
-    not: rt.makeFunction((x) => !x),
-    list: rt.makeFunction((...args) => Cons.from(args)),
-    length: rt.makeFunction((obj) => {
-      if (obj instanceof Cons) {
-        let i = 0;
-        for (let _ of obj) {
-          i++;
+    "=": rt.makeFunction((a, b) => a === b, {
+      contract: "(number, number -> boolean)",
+    }),
+    ">": rt.makeFunction((a, b) => a > b, {
+      contract: "(number, number -> boolean)",
+    }),
+    ">=": rt.makeFunction((a, b) => a >= b, {
+      contract: "(number, number -> boolean)",
+    }),
+    "<": rt.makeFunction((a, b) => a < b, {
+      contract: "(number, number -> boolean)",
+    }),
+    "<=": rt.makeFunction((a, b) => a <= b, {
+      contract: "(number, number -> boolean)",
+    }),
+    not: rt.makeFunction((x) => !x, { contract: "(any -> boolean)" }),
+    list: rt.makeFunction((...args) => Cons.from(args), {
+      contract: "(&(vector any) -> (list any))",
+    }),
+    length: rt.makeFunction(
+      (obj) => {
+        if (obj instanceof Cons) {
+          let i = 0;
+          for (let _ of obj) {
+            i++;
+          }
+          return i;
         }
-        return i;
-      }
 
-      return obj.length;
-    }),
-    get: rt.makeFunction((n, obj) => {
-      const value = obj.get(n);
-
-      if (value === undefined) {
-        throw new Exception(`Value for index ${n} not found on object`);
-      }
-
-      return value;
-    }),
-    "list?": rt.makeFunction(isList),
-    "pair?": rt.makeFunction((obj) => obj instanceof Cons),
-    "number?": rt.makeFunction((obj) => typeof obj === "number"),
-    "string?": rt.makeFunction((obj) => typeof obj === "string"),
-    "boolean?": rt.makeFunction((obj) => typeof obj === "boolean"),
-    "nil?": rt.makeFunction((obj) => obj == null),
-    "keyword?": rt.makeFunction(
-      (obj) => typeof obj === "symbol" && obj.description.startsWith(":")
+        return obj.length;
+      },
+      { contract: "((list any) -> number)" }
     ),
-    "equal?": rt.makeFunction((a, b) => {
-      if (rt.hasDict(a) && rt.hasDict(b)) {
-        return equal(rt.getMetaField(a, "dict"), rt.getMetaField(b, "dict"));
-      }
-      return equal(a, b);
+    get: rt.makeFunction(
+      (n, obj) => {
+        const value = obj.get(n);
+
+        if (value === undefined) {
+          throw new Exception(`Value for index ${n} not found on object`);
+        }
+
+        return value;
+      },
+      { contract: "((list any) -> any)" }
+    ),
+    "list?": rt.makeFunction(isList, { contract: "((list any) -> boolean)" }),
+    "pair?": rt.makeFunction((obj) => obj instanceof Cons, {
+      contract: "((list any) -> boolean)",
     }),
-    "is?": rt.makeFunction((a, b) => Object.is(a, b)),
-    append: rt.makeFunction((obj1, obj2) => {
-      if (typeof obj1 === "string" && typeof obj2 === "string") {
-        return obj1 + obj2;
-      } else if (obj1 instanceof Cons) {
-        return Cons.from(obj1).append(obj2);
-      } else if (Array.isArray(obj1)) {
-        return [...obj1].push(obj2);
-      } else {
-        rt.failRuntime(`Value of type ${typeof obj1} cannot be appended`);
-      }
+    "number?": rt.makeFunction((obj) => typeof obj === "number", {
+      contract: "(any -> boolean)",
     }),
-    with: rt.makeFunction((rec1, rec2) => {
-      const newDict = Object.assign(
-        {},
-        rt.getMetaField(rec1, "dict"),
-        rt.getMetaField(rec2, "dict")
-      );
-      return rt.makeObject(newDict);
+    "string?": rt.makeFunction((obj) => typeof obj === "string", {
+      contract: "(any -> boolean)",
     }),
-    prop: rt.makeFunction((prop, obj) => rt.getField(obj, prop)),
+    "boolean?": rt.makeFunction((obj) => typeof obj === "boolean", {
+      contract: "(any -> boolean)",
+    }),
+    "nil?": rt.makeFunction((obj) => obj == null, {
+      contract: "(any -> boolean)",
+    }),
+    "keyword?": rt.makeFunction(
+      (obj) => typeof obj === "symbol" && obj.description.startsWith(":"),
+      { contract: "(any -> boolean)" }
+    ),
+    "equal?": rt.makeFunction(
+      (a, b) => {
+        if (rt.hasDict(a) && rt.hasDict(b)) {
+          return equal(rt.getMetaField(a, "dict"), rt.getMetaField(b, "dict"));
+        }
+        return equal(a, b);
+      },
+      { contract: "(any, any) -> boolean" }
+    ),
+    "is?": rt.makeFunction((a, b) => Object.is(a, b), {
+      contract: "(any, any -> boolean)",
+    }),
+    append: rt.makeFunction(
+      (obj1, obj2) => {
+        if (typeof obj1 === "string" && typeof obj2 === "string") {
+          return obj1 + obj2;
+        } else if (obj1 instanceof Cons) {
+          return Cons.from(obj1).append(obj2);
+        } else if (Array.isArray(obj1)) {
+          return [...obj1].push(obj2);
+        } else {
+          rt.failRuntime(`Value of type ${typeof obj1} cannot be appended`);
+        }
+      },
+      { contract: "(any, any -> any)" }
+    ),
+    with: rt.makeFunction(
+      (rec1, rec2) => {
+        const newDict = Object.assign(
+          {},
+          rt.getMetaField(rec1, "dict"),
+          rt.getMetaField(rec2, "dict")
+        );
+        return rt.makeObject(newDict);
+      },
+      { contract: "(any, any -> any)" }
+    ),
+    prop: rt.makeFunction((prop, obj) => rt.getField(obj, prop), {
+      contract: "(string, any -> any)",
+    }),
   };
 });

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -20,7 +20,6 @@ export const theModule = makeModule("Core", (rt, ns) => {
   };
 
   return {
-    __module__: "Global",
     print: rt.makeFunction(print, { contract: "(any -> string)" }),
     println: rt.makeFunction(println, { contract: "(any -> string)" }),
     cons: rt.makeFunction(cons, { contract: "(any, any -> (list any))" }),

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -201,5 +201,18 @@ export const theModule = makeModule("Core", (rt, ns) => {
         contract: "((any, any -> any), any, (list any) -> any)",
       }
     ),
+    "fold-r": rt.makeFunction(
+      (fn, init, lst) => {
+        let acc = init;
+        const reversed = [...lst].reverse();
+        for (let item of reversed) {
+          acc = fn(acc, item);
+        }
+        return acc;
+      },
+      {
+        contract: "((any, any -> any), any, (list any) -> any)",
+      }
+    ),
   };
 });

--- a/lib/js/core.js
+++ b/lib/js/core.js
@@ -163,5 +163,43 @@ export const theModule = makeModule("Core", (rt, ns) => {
     prop: rt.makeFunction((prop, obj) => rt.getField(obj, prop), {
       contract: "(string, any -> any)",
     }),
+    map: rt.makeFunction(
+      (fn, lst) => {
+        let mapped = [];
+        for (let item of lst) {
+          mapped.push(fn(item));
+        }
+        return Cons.from(mapped);
+      },
+      {
+        contract: "((any -> any), (list any) -> (list any))",
+      }
+    ),
+    filter: rt.makeFunction(
+      (fn, lst) => {
+        let filtered = [];
+        for (let item of lst) {
+          if (rt.isTruthy(fn(item))) {
+            filtered.push(item);
+          }
+        }
+        return Cons.from(filtered);
+      },
+      {
+        contract: "((any -> boolean), (list any) -> (list any))",
+      }
+    ),
+    fold: rt.makeFunction(
+      (fn, init, lst) => {
+        let acc = init;
+        for (let item of lst) {
+          acc = fn(acc, item);
+        }
+        return acc;
+      },
+      {
+        contract: "((any, any -> any), any, (list any) -> any)",
+      }
+    ),
   };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "esbuild": "^0.17.19",
         "fast-deep-equal": "^3.1.3",
         "object-hash": "^3.0.0",
+        "ramda": "^0.29.0",
         "readline-sync": "^1.4.10"
       },
       "bin": {
@@ -3401,6 +3402,15 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
+    },
+    "node_modules/ramda": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
+      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
     },
     "node_modules/react-is": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "esbuild": "^0.17.19",
     "fast-deep-equal": "^3.1.3",
     "object-hash": "^3.0.0",
+    "ramda": "^0.29.0",
     "readline-sync": "^1.4.10"
   },
   "devDependencies": {

--- a/src/cli/repl.js
+++ b/src/cli/repl.js
@@ -36,9 +36,11 @@ export const repl = (mode = "repl") => {
           process.exit(0);
         case ":print-ast":
           mode = "printAST";
+          input = "";
           break;
         case ":print-desugared":
           mode = "printDesugared";
+          input = "";
           break;
         // If it's code, compile and run it
         default:

--- a/src/cli/repl.js
+++ b/src/cli/repl.js
@@ -62,6 +62,8 @@ export const repl = (mode = "repl") => {
       }
     } catch (e) {
       console.error(e.stack);
+      input = "";
+      indent = 0;
     }
   }
 };

--- a/src/desugarer/Desugarer.js
+++ b/src/desugarer/Desugarer.js
@@ -41,6 +41,7 @@ export class Desugarer extends Visitor {
       node.retType,
       node.srcloc
     );
+    lambda.type = type;
     const paramTypes = node.params.map(
       (p) => p.typeAnnotation ?? { kind: TATypes.AnyLiteral }
     );

--- a/src/desugarer/Desugarer.js
+++ b/src/desugarer/Desugarer.js
@@ -1,3 +1,5 @@
+import { AST } from "../parser/ast.js";
+import { TATypes } from "../parser/parseTypeAnnotation.js";
 import { Visitor } from "../visitor/Visitor.js";
 
 /**
@@ -5,8 +7,49 @@ import { Visitor } from "../visitor/Visitor.js";
  * @desc Desugars the AST into core forms
  * @extends Visitor
  */
-class Desugarer extends Visitor {
+export class Desugarer extends Visitor {
+  /**
+   * Constructor
+   * @param {AST} program
+   */
   constructor(program) {
     super(program);
+  }
+
+  /**
+   * Static constructor
+   * @param {AST} program
+   * @returns {Desugarer}
+   */
+  static new(program) {
+    return new Desugarer(program);
+  }
+
+  /**
+   * Desugars a FunctionDefinition node into a VariableDeclaration with lambda
+   * @param {import("../parser/ast.js").FunctionDeclaration} node
+   * @returns {import("../parser/ast.js").VariableDeclaration}
+   */
+  visitFunctionDeclaration(node) {
+    const variadic = node.variadic;
+    const lambda = AST.LambdaExpression(
+      node.params,
+      node.body,
+      variadic,
+      node.retType,
+      node.srcloc
+    );
+    const paramTypes = node.params.map(
+      (p) => p.typeAnnotation ?? { kind: TATypes.AnyLiteral }
+    );
+    const retType = node.retType ?? { kind: TATypes.AnyLiteral };
+    const funcType = {
+      kind: TATypes.Function,
+      params: paramTypes,
+      retType,
+      variadic,
+    };
+
+    return AST.VariableDeclaration(node.name, lambda, node.srcloc, funcType);
   }
 }

--- a/src/desugarer/Desugarer.js
+++ b/src/desugarer/Desugarer.js
@@ -10,7 +10,7 @@ import { Visitor } from "../visitor/Visitor.js";
 export class Desugarer extends Visitor {
   /**
    * Constructor
-   * @param {AST} program
+   * @param {import("../typechecker/TypeChecker.js").TypedAST} program
    */
   constructor(program) {
     super(program);
@@ -18,7 +18,7 @@ export class Desugarer extends Visitor {
 
   /**
    * Static constructor
-   * @param {AST} program
+   * @param {import("../typechecker/TypeChecker.js").TypedAST} program
    * @returns {Desugarer}
    */
   static new(program) {
@@ -27,11 +27,13 @@ export class Desugarer extends Visitor {
 
   /**
    * Desugars a FunctionDefinition node into a VariableDeclaration with lambda
-   * @param {import("../parser/ast.js").FunctionDeclaration} node
-   * @returns {import("../parser/ast.js").VariableDeclaration}
+   * @param {import("../parser/ast.js").FunctionDeclaration & {type: import("../typechecker/types.js").Type}} node
+   * @returns {import("../parser/ast.js").VariableDeclaration & {type: import("../typechecker/types.js").Type}}
    */
   visitFunctionDeclaration(node) {
     const variadic = node.variadic;
+    // since it's TypedAST it has a type property
+    const type = node.type;
     const lambda = AST.LambdaExpression(
       node.params,
       node.body,
@@ -50,6 +52,9 @@ export class Desugarer extends Visitor {
       variadic,
     };
 
-    return AST.VariableDeclaration(node.name, lambda, node.srcloc, funcType);
+    const varDecl = AST.VariableDeclaration(node.name, lambda, node.srcloc, funcType);
+
+    varDecl.type = type;
+    return varDecl
   }
 }

--- a/src/desugarer/Desugarer.js
+++ b/src/desugarer/Desugarer.js
@@ -53,9 +53,14 @@ export class Desugarer extends Visitor {
       variadic,
     };
 
-    const varDecl = AST.VariableDeclaration(node.name, lambda, node.srcloc, funcType);
+    const varDecl = AST.VariableDeclaration(
+      node.name,
+      lambda,
+      node.srcloc,
+      funcType
+    );
 
     varDecl.type = type;
-    return varDecl
+    return varDecl;
   }
 }

--- a/src/desugarer/Desugarer.js
+++ b/src/desugarer/Desugarer.js
@@ -1,0 +1,12 @@
+import { Visitor } from "../visitor/Visitor.js";
+
+/**
+ * @class
+ * @desc Desugars the AST into core forms
+ * @extends Visitor
+ */
+class Desugarer extends Visitor {
+  constructor(program) {
+    super(program);
+  }
+}

--- a/src/desugarer/Desugarer.js
+++ b/src/desugarer/Desugarer.js
@@ -4,7 +4,7 @@ import { Visitor } from "../visitor/Visitor.js";
 
 /**
  * @class
- * @desc Desugars the AST into core forms
+ * @desc Desugars the typed AST into core forms
  * @extends Visitor
  */
 export class Desugarer extends Visitor {

--- a/src/desugarer/desugar.js
+++ b/src/desugarer/desugar.js
@@ -1,3 +1,4 @@
+import { Desugarer } from "./Desugarer.js";
 /**
  * @typedef {import("../parser/ast.js").AST} AST
  */
@@ -6,4 +7,4 @@
  * @param {AST} ast
  * @returns {AST}
  */
-export const desugar = (ast) => ast;
+export const desugar = (ast) => Desugarer.new().visit(ast);

--- a/src/desugarer/desugar.js
+++ b/src/desugarer/desugar.js
@@ -1,10 +1,8 @@
 import { Desugarer } from "./Desugarer.js";
-/**
- * @typedef {import("../parser/ast.js").AST} AST
- */
+
 /**
  * Desugars the AST into an AST that contains only core forms
- * @param {AST} ast
- * @returns {AST}
+ * @param {import("../typechecker/TypeChecker.js").TypedAST} ast
+ * @returns {import("../typechecker/TypeChecker.js").TypedAST}
  */
 export const desugar = (ast) => Desugarer.new().visit(ast);

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -40,7 +40,6 @@ export class Emitter {
    * @returns {string}
    */
   emit(node = this.program, ns = this.ns) {
-    console.log(node)
     switch (node.kind) {
       case ASTTypes.Program:
         return this.emitProgram(node, ns);
@@ -151,7 +150,7 @@ export class Emitter {
     let i = 0;
 
     for (let p of node.params) {
-      funcNs.set(p.name, makeSymbol(p.name));
+      funcNs.set(p.name.name, makeSymbol(p.name));
 
       if (node.variadic && i === node.params.length - 1) {
         params.push(`...${this.emit(p.name, funcNs)}`);
@@ -161,7 +160,7 @@ export class Emitter {
       i++;
     }
 
-    let code = `(${params.join(", ")}) => {`
+    let code = `(${params.join(", ")}) => {\n`
 
     let j = 0;
     for (let expr of node.body) {
@@ -173,7 +172,7 @@ export class Emitter {
       j++;
     }
 
-    code += "}"
+    code += "\n}"
 
     return code;
   }
@@ -297,6 +296,9 @@ export class Emitter {
   emitSymbol(node, ns) {
     const name = node.name;
     const emittedName = ns.get(name);
+    console.log(ns);
+    console.log(name);
+    console.log(emittedName);
 
     if (!emittedName) {
       throw new ReferenceException(

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -160,7 +160,7 @@ export class Emitter {
       i++;
     }
 
-    let code = `(${params.join(", ")}) => {\n`;
+    let code = `rt.makeFunction((${params.join(", ")}) => {\n`;
 
     let j = 0;
     for (let expr of node.body) {
@@ -172,7 +172,7 @@ export class Emitter {
       j++;
     }
 
-    code += "\n}";
+    code += "\n})";
 
     return code;
   }

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -75,6 +75,8 @@ export class Emitter {
         return this.emitVectorLiteral(node, ns);
       case ASTTypes.VectorPattern:
         return this.emitVectorPattern(node, ns);
+      case ASTTypes.LambdaExpression:
+        return this.emitLambdaExpression(node, ns);
       default:
         throw new SyntaxException(node.kind, node.srcloc);
     }

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -40,6 +40,7 @@ export class Emitter {
    * @returns {string}
    */
   emit(node = this.program, ns = this.ns) {
+    console.log(node)
     switch (node.kind) {
       case ASTTypes.Program:
         return this.emitProgram(node, ns);
@@ -153,9 +154,9 @@ export class Emitter {
       funcNs.set(p.name, makeSymbol(p.name));
 
       if (node.variadic && i === node.params.length - 1) {
-        params.push(`...${this.emit(p, funcNs)}`);
+        params.push(`...${this.emit(p.name, funcNs)}`);
       } else {
-        params.push(this.emit(p, funcNs));
+        params.push(this.emit(p.name, funcNs));
       }
       i++;
     }

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -137,6 +137,45 @@ export class Emitter {
   }
 
   /**
+   * Generates code from a LambdaExpression AST node
+   * @param {import("../parser/ast.js").LambdaExpression} node
+   * @param {Namespace} ns
+   */
+  emitLambdaExpression(node, ns) {
+    const funcNs = ns.extend("Lambda");
+    /** @type {string[]} */
+    let params = [];
+    let i = 0;
+
+    for (let p of node.params) {
+      funcNs.set(p.name, makeSymbol(p.name));
+
+      if (node.variadic && i === node.params.length - 1) {
+        params.push(`...${this.emit(p, funcNs)}`);
+      } else {
+        params.push(this.emit(p, funcNs));
+      }
+      i++;
+    }
+
+    let code = `(${params.join(", ")}) => {`
+
+    let j = 0;
+    for (let expr of node.body) {
+      if (j === node.body.length - 1) {
+        code += `return ${this.emit(expr, funcNs)};`;
+      } else {
+        code += this.emit(expr, funcNs) + ";\n";
+      }
+      j++;
+    }
+
+    code += "}"
+
+    return code;
+  }
+
+  /**
    * Generates code from a MemberExpression AST node
    * @param {import("../parser/ast.js").MemberExpression} node
    * @param {Namespace} ns

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -160,7 +160,7 @@ export class Emitter {
       i++;
     }
 
-    let code = `(${params.join(", ")}) => {\n`
+    let code = `(${params.join(", ")}) => {\n`;
 
     let j = 0;
     for (let expr of node.body) {
@@ -172,7 +172,7 @@ export class Emitter {
       j++;
     }
 
-    code += "\n}"
+    code += "\n}";
 
     return code;
   }

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -296,9 +296,6 @@ export class Emitter {
   emitSymbol(node, ns) {
     const name = node.name;
     const emittedName = ns.get(name);
-    console.log(ns);
-    console.log(name);
-    console.log(emittedName);
 
     if (!emittedName) {
       throw new ReferenceException(

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -90,13 +90,13 @@ export const ASTTypes = {
 /**
  * @typedef Param
  * @prop {Symbol} name
- * @prop {import("./parseTypeAnnotation.js").TypeAnnotation} typeAnnotation
+ * @prop {import("./parseTypeAnnotation.js").TypeAnnotation|null} typeAnnotation
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; name: Symbol; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation}} FunctionDeclaration
+ * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; name: Symbol; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation|null}} FunctionDeclaration
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation}} LambdaExpression
+ * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation|null}} LambdaExpression
  */
 /**
  * @typedef {Symbol|VectorPattern|RecordPattern} LHV
@@ -360,7 +360,7 @@ export const AST = {
    * @param {Symbol[]} params
    * @param {AST[]} body
    * @param {boolean} variadic
-   * @param {import("./parseTypeAnnotation.js").TypeAnnotation} retType
+   * @param {import("./parseTypeAnnotation.js").TypeAnnotation|null} retType
    * @returns {FunctionDeclaration}
    */
   FunctionDeclaration(name, params, body, variadic, retType) {
@@ -379,7 +379,7 @@ export const AST = {
    * @param {Symbol[]} params
    * @param {AST[]} body
    * @param {boolean} variadic
-   * @param {import("./parseTypeAnnotation.js").TypeAnnotation} retType
+   * @param {import("./parseTypeAnnotation.js").TypeAnnotation|null} retType
    * @returns {LambdaExpression}
    */
   LambdaExpression(params, body, variadic, retType) {

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -23,6 +23,8 @@ export const ASTTypes = {
   RecordLiteral: "RecordLiteral",
   RecordPattern: "RecordPattern",
   MemberExpression: "MemberExpression",
+  FunctionDeclaration: "FunctionDeclaration",
+  LambdaExpression: "LambdaExpression",
 };
 
 /**
@@ -84,6 +86,12 @@ export const ASTTypes = {
  */
 /**
  * @typedef {ASTNode & {kind: ASTTypes.MemberExpression; object: AST; property: Symbol}} MemberExpression
+ */
+/**
+ * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; name: Symbol; params: Symbol[]; body: AST[]; variadic: boolean}} FunctionDeclaration
+ */
+/**
+ * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; params: Symbol[]; body: AST[]; variadic: boolean}} LambdaExpression
  */
 /**
  * @typedef {Symbol|VectorPattern|RecordPattern} LHV
@@ -339,6 +347,39 @@ export const AST = {
       object,
       property,
       srcloc,
+    };
+  },
+  /**
+   * Constructs a FunctionDeclaration AST node
+   * @param {Symbol} name
+   * @param {Symbol[]} params
+   * @param {AST[]} body
+   * @param {boolean} variadic
+   * @returns {FunctionDeclaration}
+   */
+  FunctionDeclaration(name, params, body, variadic) {
+    return {
+      kind: ASTTypes.FunctionDeclaration,
+      name,
+      params,
+      body,
+      variadic,
+    };
+  },
+
+  /**
+   * Constructs a LambdaExpression AST node
+   * @param {Symbol[]} params
+   * @param {AST[]} body
+   * @param {boolean} variadic
+   * @returns {LambdaExpression}
+   */
+  LambdaExpression(params, body, variadic) {
+    return {
+      kind: ASTTypes.LambdaExpression,
+      params,
+      body,
+      variadic,
     };
   },
 };

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -1,5 +1,6 @@
 import { SrcLoc } from "../lexer/SrcLoc.js";
 import { Token } from "../lexer/Token.js";
+import { TypeEnvironment } from "../typechecker/TypeEnvironment.js";
 
 /**
  * @enum {string}
@@ -64,7 +65,7 @@ export const ASTTypes = {
  * @typedef {ASTNode & {kind: ASTTypes.SetExpression; lhv: LHV, expression: AST}} SetExpression
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.DoExpression; body: AST[]}} DoExpression
+ * @typedef {ASTNode & {kind: ASTTypes.DoExpression; body: AST[], env?: TypeEnvironment}} DoExpression
  */
 /**
  * @typedef {ASTNode & {kind: ASTTypes.TypeAlias; name: string; type: import("./parseTypeAnnotation.js").TypeAnnotation}} TypeAlias
@@ -93,10 +94,10 @@ export const ASTTypes = {
  * @prop {import("./parseTypeAnnotation.js").TypeAnnotation|null} typeAnnotation
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; name: Symbol; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation|null}} FunctionDeclaration
+ * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; name: Symbol; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation|null; env?: TypeEnvironment}} FunctionDeclaration
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation|null}} LambdaExpression
+ * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation|null; env?: TypeEnvironment}} LambdaExpression
  */
 /**
  * @typedef {Symbol|VectorPattern|RecordPattern} LHV

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -24,6 +24,7 @@ export const ASTTypes = {
   RecordLiteral: "RecordLiteral",
   RecordPattern: "RecordPattern",
   MemberExpression: "MemberExpression",
+  Param: "Param",
   FunctionDeclaration: "FunctionDeclaration",
   LambdaExpression: "LambdaExpression",
 };
@@ -90,6 +91,7 @@ export const ASTTypes = {
  */
 /**
  * @typedef Param
+ * @prop {ASTTypes.Param} kind
  * @prop {Symbol} name
  * @prop {import("./parseTypeAnnotation.js").TypeAnnotation|null} typeAnnotation
  */
@@ -97,7 +99,7 @@ export const ASTTypes = {
  * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; name: Symbol; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation|null; env?: TypeEnvironment}} FunctionDeclaration
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation|null; env?: TypeEnvironment}} LambdaExpression
+ * @typedef {ASTNode & {kind: ASTTypes.LambdaExpression; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation|null; env?: TypeEnvironment}} LambdaExpression
  */
 /**
  * @typedef {Symbol|VectorPattern|RecordPattern} LHV

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -88,10 +88,15 @@ export const ASTTypes = {
  * @typedef {ASTNode & {kind: ASTTypes.MemberExpression; object: AST; property: Symbol}} MemberExpression
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; name: Symbol; params: Symbol[]; body: AST[]; variadic: boolean}} FunctionDeclaration
+ * @typedef Param
+ * @prop {Symbol} name
+ * @prop {import("./parseTypeAnnotation.js").TypeAnnotation} typeAnnotation
  */
 /**
- * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; params: Symbol[]; body: AST[]; variadic: boolean}} LambdaExpression
+ * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; name: Symbol; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation}} FunctionDeclaration
+ */
+/**
+ * @typedef {ASTNode & {kind: ASTTypes.FunctionDeclaration; params: Param[]; body: AST[]; variadic: boolean; retType: import("./parseTypeAnnotation.js").TypeAnnotation}} LambdaExpression
  */
 /**
  * @typedef {Symbol|VectorPattern|RecordPattern} LHV
@@ -100,7 +105,7 @@ export const ASTTypes = {
  * @typedef {NumberLiteral|StringLiteral|BooleanLiteral|KeywordLiteral|NilLiteral} Primitive
  */
 /**
- * @typedef {Program|Primitive|Symbol|CallExpression|VariableDeclaration|SetExpression|DoExpression|TypeAlias} AST
+ * @typedef {Program|Primitive|Symbol|CallExpression|VariableDeclaration|SetExpression|DoExpression|TypeAlias|RecordLiteral|RecordPattern|VectorLiteral|VectorPattern|MemberExpression|FunctionDeclaration|LambdaExpression} AST
  */
 export const AST = {
   /**
@@ -355,15 +360,17 @@ export const AST = {
    * @param {Symbol[]} params
    * @param {AST[]} body
    * @param {boolean} variadic
+   * @param {import("./parseTypeAnnotation.js").TypeAnnotation} retType
    * @returns {FunctionDeclaration}
    */
-  FunctionDeclaration(name, params, body, variadic) {
+  FunctionDeclaration(name, params, body, variadic, retType) {
     return {
       kind: ASTTypes.FunctionDeclaration,
       name,
       params,
       body,
       variadic,
+      retType,
     };
   },
 
@@ -372,14 +379,16 @@ export const AST = {
    * @param {Symbol[]} params
    * @param {AST[]} body
    * @param {boolean} variadic
+   * @param {import("./parseTypeAnnotation.js").TypeAnnotation} retType
    * @returns {LambdaExpression}
    */
-  LambdaExpression(params, body, variadic) {
+  LambdaExpression(params, body, variadic, retType) {
     return {
       kind: ASTTypes.LambdaExpression,
       params,
       body,
       variadic,
+      retType,
     };
   },
 };

--- a/src/parser/ast.js
+++ b/src/parser/ast.js
@@ -364,9 +364,10 @@ export const AST = {
    * @param {AST[]} body
    * @param {boolean} variadic
    * @param {import("./parseTypeAnnotation.js").TypeAnnotation|null} retType
+   * @param {SrcLoc}
    * @returns {FunctionDeclaration}
    */
-  FunctionDeclaration(name, params, body, variadic, retType) {
+  FunctionDeclaration(name, params, body, variadic, retType, srcloc) {
     return {
       kind: ASTTypes.FunctionDeclaration,
       name,
@@ -374,6 +375,7 @@ export const AST = {
       body,
       variadic,
       retType,
+      srcloc,
     };
   },
 
@@ -383,15 +385,17 @@ export const AST = {
    * @param {AST[]} body
    * @param {boolean} variadic
    * @param {import("./parseTypeAnnotation.js").TypeAnnotation|null} retType
+   * @param {SrcLoc} srcloc
    * @returns {LambdaExpression}
    */
-  LambdaExpression(params, body, variadic, retType) {
+  LambdaExpression(params, body, variadic, retType, srcloc) {
     return {
       kind: ASTTypes.LambdaExpression,
       params,
       body,
       variadic,
       retType,
+      srcloc,
     };
   },
 };

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -63,14 +63,14 @@ const parseVariableDeclaration = (decl) => {
   if (lhv instanceof Cons) {
     // has type annotation
     const realLhv = lhv.get(0);
-    // convert to array and get rid of ":" when passing into parseTypeAnnotation
-    typeAnnotation = [...lhv.cdr].slice(1);
+    // skip over : and get type annotation
+    typeAnnotation = lhv.cdr.cdr;
 
-    if (typeAnnotation[0]?.constructor?.name === "Cons") {
-      // is function type annotation
-      typeAnnotation = flattenFunctionTypeAnnotation(typeAnnotation);
+    if (typeAnnotation.cdr === null) {
+      // is a simple annotation, otherwise it's a Cons type annotation
+      typeAnnotation = typeAnnotation.car;
     }
-
+    // parse type annotation
     typeAnnotation = parseTypeAnnotation(typeAnnotation);
     parsedLhv = parseExpr(realLhv);
   } else {

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -246,7 +246,7 @@ const parseParams = (forms) => {
         i += 2;
       }
 
-      params.push({ name, typeAnnotation });
+      params.push({ kind: ASTTypes.Param, name, typeAnnotation });
     } else if (form.type === TokenTypes.Amp) {
       continue;
     }

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -347,12 +347,11 @@ const parseFunction = (
   }
 
   const variadic = [...params].reduce((isVar, param) => {
-    if (isVar === true) return isVar;
     if (param.type === TokenTypes.Amp) {
       return true;
     }
 
-    return false;
+    return isVar;
   }, false);
   const parsedParams = parseParams(params);
   const parsedBody = parseExpr(body);

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -247,6 +247,7 @@ const parseParams = (forms) => {
 
           annot = flattenFunctionTypeAnnotation(annot);
           typeAnnotation = parseTypeAnnotation(annot);
+          i += 2;
         } else if (forms[i + 3]?.constructor?.name === "Cons") {
           // is a generic type annotation
           const annot = cons(forms[i + 2], forms[i + 3]);

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -261,7 +261,7 @@ const parseParams = (forms) => {
  * @returns {import("./ast.js").FunctionDeclaration}
  */
 const parseFunctionDeclaration = (form) => {
-  const [_, name, params, maybeArrow, maybeRetType, maybeBody] = form;
+  const [_, name, params, maybeArrow, maybeRetType, ...maybeBody] = form;
   const parsedName = parseExpr(name);
   const { parsedParams, parsedBody, variadic, retType } = parseFunction(
     params,
@@ -285,7 +285,7 @@ const parseFunctionDeclaration = (form) => {
  * @returns {import("./ast.js").LambdaExpression}
  */
 const parseLambdaExpression = (form) => {
-  const [_, params, maybeArrow, maybeRetType, maybeBody] = form;
+  const [_, params, maybeArrow, maybeRetType, ...maybeBody] = form;
   const { parsedParams, parsedBody, variadic, retType } = parseFunction(
     params,
     maybeArrow,
@@ -305,7 +305,7 @@ const parseFunction = (params, maybeArrow, maybeRetType, maybeBody) => {
     body = maybeBody;
   } else {
     retType = null;
-    body = maybeArrow;
+    body = [maybeArrow, ...maybeBody];
   }
 
   const variadic = [...params].reduce((isVar, param) => {
@@ -316,7 +316,8 @@ const parseFunction = (params, maybeArrow, maybeRetType, maybeBody) => {
     return isVar;
   }, false);
   const parsedParams = parseParams(params);
-  const parsedBody = parseExpr(body);
+  /** @type {AST[]} */
+  const parsedBody = body.map(parseExpr);
 
   return {
     parsedParams,

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -333,8 +333,9 @@ const parseFunction = (
 
   if (maybeArrow.type === TokenTypes.Symbol && maybeArrow.value === "->") {
     if (maybeCons?.constructor?.name === "Cons") {
-      let ret = cons(maybeRetType, maybeCons);
-      retType = parseTypeAnnotation(ret);
+      // is generic annotation
+      maybeRetType = cons(maybeRetType, maybeCons);
+      retType = parseTypeAnnotation(maybeRetType);
       body = maybeBody;
     } else {
       retType = parseTypeAnnotation(maybeRetType);

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -262,6 +262,7 @@ const parseParams = (forms) => {
  */
 const parseFunctionDeclaration = (form) => {
   const [_, name, params, maybeArrow, maybeRetType, ...maybeBody] = form;
+  const srcloc = form.srcloc;
   const parsedName = parseExpr(name);
   const { parsedParams, parsedBody, variadic, retType } = parseFunction(
     params,
@@ -275,7 +276,8 @@ const parseFunctionDeclaration = (form) => {
     parsedParams,
     parsedBody,
     variadic,
-    retType
+    retType,
+    srcloc
   );
 };
 
@@ -286,6 +288,7 @@ const parseFunctionDeclaration = (form) => {
  */
 const parseLambdaExpression = (form) => {
   const [_, params, maybeArrow, maybeRetType, ...maybeBody] = form;
+  const srcloc = form.srcloc;
   const { parsedParams, parsedBody, variadic, retType } = parseFunction(
     params,
     maybeArrow,
@@ -293,7 +296,13 @@ const parseLambdaExpression = (form) => {
     maybeBody
   );
 
-  return AST.LambdaExpression(parsedParams, parsedBody, variadic, retType);
+  return AST.LambdaExpression(
+    parsedParams,
+    parsedBody,
+    variadic,
+    retType,
+    srcloc
+  );
 };
 
 const parseFunction = (params, maybeArrow, maybeRetType, maybeBody) => {

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -261,8 +261,7 @@ const parseParams = (forms) => {
  * @returns {import("./ast.js").FunctionDeclaration}
  */
 const parseFunctionDeclaration = (form) => {
-  const [_, name, params, maybeArrow, maybeRetType, maybeBody] =
-    form;
+  const [_, name, params, maybeArrow, maybeRetType, maybeBody] = form;
   const parsedName = parseExpr(name);
   const { parsedParams, parsedBody, variadic, retType } = parseFunction(
     params,
@@ -297,12 +296,7 @@ const parseLambdaExpression = (form) => {
   return AST.LambdaExpression(parsedParams, parsedBody, variadic, retType);
 };
 
-const parseFunction = (
-  params,
-  maybeArrow,
-  maybeRetType,
-  maybeBody
-) => {
+const parseFunction = (params, maybeArrow, maybeRetType, maybeBody) => {
   let retType, body;
 
   if (maybeArrow.type === TokenTypes.Symbol && maybeArrow.value === "->") {

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -279,6 +279,11 @@ const parseFunctionDeclaration = (form) => {
   );
 };
 
+/**
+ * Parses a lambda expression
+ * @param {List} form
+ * @returns {import("./ast.js").LambdaExpression}
+ */
 const parseLambdaExpression = (form) => {
   const [_, params, maybeArrow, maybeRetType, maybeCons, maybeBody] = form;
   const { parsedParams, parsedBody, variadic, retType } = parseFunction(

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -234,11 +234,20 @@ const parseParams = (forms) => {
         forms[i + 1]?.type === TokenTypes.Keyword &&
         forms[i + 1].value === ":"
       ) {
-        if (forms[i + 3]?.constructor?.name === "Cons") {
+        if (forms[i + 2]?.constructor?.name === "Cons") {
+          // is a function type annotation
+          let annot = forms[i + 2];
+
+          // flatten the annotation into an array
+          const args = [...annot[0]];
+          annot = args.concat([...annot]);
+        } else if (forms[i + 3]?.constructor?.name === "Cons") {
+          // is a generic type annotation
           const annot = cons(forms[i + 2], forms[i + 3]);
           typeAnnotation = parseTypeAnnotation(annot);
           i += 3;
         } else {
+          // is a simple type annotation
           typeAnnotation = parseTypeAnnotation(forms[i + 2]);
           i += 2;
         }

--- a/src/parser/parseTypeAnnotation.js
+++ b/src/parser/parseTypeAnnotation.js
@@ -120,8 +120,6 @@ const parseObjectAnnotation = (annot) => {
  * @returns {TypeAnnotation}
  */
 export const parseTypeAnnotation = (annotation) => {
-  let annot;
-
   if (annotation instanceof Cons) {
     // is function or generic annotation
     // flatten Cons to array
@@ -159,6 +157,7 @@ export const parseTypeAnnotation = (annotation) => {
     }
   }
 
+  let annot;
   if (Array.isArray(annotation)) {
     // is generic annotation
     // get container type

--- a/src/parser/parseTypeAnnotation.js
+++ b/src/parser/parseTypeAnnotation.js
@@ -127,6 +127,7 @@ export const parseTypeAnnotation = (annotation) => {
     // flatten Cons to array
     annotation = [...annotation];
 
+    // if it has an arrow, it's a function annotation
     const hasArrow = annotation.reduce((hasArrow, item) => {
       if (item.type === TokenTypes.Symbol && item.value === "->") {
         return true;

--- a/src/parser/parseTypeAnnotation.js
+++ b/src/parser/parseTypeAnnotation.js
@@ -71,12 +71,13 @@ export const TATypes = {
  * @typedef FunctionAnn
  * @prop {TypeAnnotation[]} params
  * @prop {TypeAnnotation} retType
+ * @prop {boolean} variadic
  */
 /**
  * @typedef {NumberAnnotation|StringAnnotation|BooleanAnnotation|KeywordAnnotation|NilAnnotation} PrimitiveAnn
  */
 /**
- * @typedef {AnyAnnotation|PrimitiveAnn|SymbolAnnotation|ListAnn|VectorAnn|ObjectAnn} TypeAnnotation
+ * @typedef {AnyAnnotation|PrimitiveAnn|SymbolAnnotation|ListAnn|VectorAnn|ObjectAnn|FunctionAnn} TypeAnnotation
  */
 /**
  * Parse the listType for a list type annotation
@@ -145,9 +146,21 @@ export const parseTypeAnnotation = (annotation) => {
   if (Array.isArray(annot)) {
     // is function annotation
     const retType = parseTypeAnnotation(annot.pop());
-    const params = annot.map(parseTypeAnnotation);
 
-    return { kind: TATypes.Function, params, retType };
+    /** @type {TypeAnnotation[]} */
+    const params = [];
+    let variadic = false;
+
+    for (let item of annot) {
+      if (item.type === TokenTypes.Amp) {
+        variadic = true;
+        continue;
+      } else {
+        params.push(parseTypeAnnotation(item));
+      }
+    }
+
+    return { kind: TATypes.Function, params, retType, variadic };
   }
 
   if (annot.type === "RecordLiteral") {

--- a/src/parser/parseTypeAnnotation.js
+++ b/src/parser/parseTypeAnnotation.js
@@ -16,6 +16,7 @@ export const TATypes = {
   List: "List",
   Vector: "Vector",
   Object: "Object",
+  Function: "Function",
 };
 /**
  * @typedef AnyAnnotation
@@ -146,7 +147,7 @@ export const parseTypeAnnotation = (annotation) => {
     const retType = parseTypeAnnotation(annot.pop());
     const params = annot.map(parseTypeAnnotation);
 
-    return { params, retType };
+    return { kind: TATypes.Function, params, retType };
   }
 
   if (annot.type === "RecordLiteral") {

--- a/src/parser/parseTypeAnnotation.js
+++ b/src/parser/parseTypeAnnotation.js
@@ -171,6 +171,10 @@ export const parseTypeAnnotation = (annotation) => {
     return parseObjectAnnotation(annot);
   }
 
+  if (annot.type === TokenTypes.Nil) {
+    return { kind: TATypes.NilLiteral };
+  }
+
   if (annot.type === TokenTypes.Symbol) {
     switch (annot.value) {
       case "any":
@@ -183,8 +187,6 @@ export const parseTypeAnnotation = (annotation) => {
         return { kind: TATypes.BooleanLiteral };
       case "keyword":
         return { kind: TATypes.KeywordLiteral };
-      case "nil":
-        return { kind: TATypes.NilLiteral };
       case "list":
         // annotation is array with listType as 2nd member
         return parseListAnnotation(annotation[1]);

--- a/src/parser/parseTypeAnnotation.js
+++ b/src/parser/parseTypeAnnotation.js
@@ -133,7 +133,7 @@ export const parseTypeAnnotation = (annotation) => {
         return true;
       }
       return hasArrow;
-    }, false)
+    }, false);
 
     if (hasArrow) {
       // is function annotation

--- a/src/printer/printAST.js
+++ b/src/printer/printAST.js
@@ -128,11 +128,11 @@ class ASTPrinter {
    * @returns {string}
    */
   printMemberExpression(node, indent) {
-    let prStr = `${prIndent(indent)}MemberExpression:`
-    prStr += `${prIndent(indent + 2)}Object:`
+    let prStr = `${prIndent(indent)}MemberExpression:`;
+    prStr += `${prIndent(indent + 2)}Object:`;
     prStr += `${this.print(node.object, indent + 4)}`;
-    prStr += `${prIndent(indent + 2)}Property:`
-    prStr += `${this.print(node.property, indent + 4)}`
+    prStr += `${prIndent(indent + 2)}Property:`;
+    prStr += `${this.print(node.property, indent + 4)}`;
 
     return prStr;
   }
@@ -173,15 +173,15 @@ class ASTPrinter {
    * @returns {string}
    */
   printRecordLiteral(node, indent) {
-    const prStr = `${prIndent(indent)}RecordLiteral:`
-    prStr += `${prIndent(indent + 2)}Properties:`
+    const prStr = `${prIndent(indent)}RecordLiteral:`;
+    prStr += `${prIndent(indent + 2)}Properties:`;
 
     for (let prop of node.properties) {
       prStr += `${this.print(prop.key, indent + 4)}`;
       prStr += `${this.print(prop.value, indent + 4)}`;
     }
 
-    return prStr
+    return prStr;
   }
 
   /**
@@ -191,7 +191,9 @@ class ASTPrinter {
    * @returns {string}
    */
   printRecordPattern(node, indent) {
-    return `${prIndent(indent)}${node.properties.map(p => p.name).join(", ")}`;
+    return `${prIndent(indent)}${node.properties
+      .map((p) => p.name)
+      .join(", ")}`;
   }
 
   /**
@@ -246,7 +248,7 @@ class ASTPrinter {
    * @returns {string}
    */
   printVectorLiteral(node, indent) {
-    let prStr = `${prIndent(indent)}VectorLiteral:`
+    let prStr = `${prIndent(indent)}VectorLiteral:`;
 
     for (let mem of node.members) {
       prStr += `${this.print(mem, indent + 2)}`;
@@ -262,7 +264,7 @@ class ASTPrinter {
    * @returns {string}
    */
   printVectorPattern(node, indent) {
-    return `${prIndent(indent)}${node.members.map (p => p.name).join(", ")}`;
+    return `${prIndent(indent)}${node.members.map((p) => p.name).join(", ")}`;
   }
 }
 

--- a/src/printer/printAST.js
+++ b/src/printer/printAST.js
@@ -122,6 +122,53 @@ class ASTPrinter {
   }
 
   /**
+   * Prints a FunctionDeclaration node
+   * @param {import("../parser/ast.js").FunctionDeclaration} node
+   * @param {number} indent
+   * @returns {string}
+   */
+  printFunctionDeclaration(node, indent) {
+    let prStr = `${prIndent(indent)}FunctionDeclaration:\n`;
+    prStr += `${prIndent(indent + 2)}Name: ${node.name.name}\n`;
+    prStr += `${prIndent(indent + 2)}Params:`;
+
+    for (let param of node.params) {
+      prStr += this.print(param, indent + 4) + "\n";
+    }
+
+    prStr += `${prIndent(indent + 2)}Body:`;
+
+    for (let expr of node.body) {
+      prStr += this.print(expr, indent + 4) + "\n";
+    }
+
+    return prStr;
+  }
+
+  /**
+   * Prints a LambdaExpression node
+   * @param {import("../parser/ast.js").LambdaExpression} node
+   * @param {number} indent
+   * @returns {string}
+   */
+  printLambdaExpression(node, indent) {
+    let prStr = `${prIndent(indent)}FunctionDeclaration:\n`;
+    prStr += `${prIndent(indent + 2)}Params:`;
+
+    for (let param of node.params) {
+      prStr += this.print(param, indent + 4) + "\n";
+    }
+
+    prStr += `${prIndent(indent + 2)}Body:`;
+
+    for (let expr of node.body) {
+      prStr += this.print(expr, indent + 4) + "\n";
+    }
+
+    return prStr;
+  }
+
+  /**
    * Prints a MemberExpression node
    * @param {import("../parser/ast.js").MemberExpression} node
    * @param {number} indent

--- a/src/printer/printAST.js
+++ b/src/printer/printAST.js
@@ -73,6 +73,10 @@ class ASTPrinter {
         return this.printVectorPattern(node, indent);
       case ASTTypes.MemberExpression:
         return this.printMemberExpression(node, indent);
+      case ASTTypes.FunctionDeclaration:
+        return this.printFunctionDeclaration(node, indent);
+      case ASTTypes.LambdaExpression:
+        return this.printLambdaExpression(node, indent);
       default:
         throw new Exception(`Unknown AST type ${node.kind} to print`);
     }
@@ -130,13 +134,13 @@ class ASTPrinter {
   printFunctionDeclaration(node, indent) {
     let prStr = `${prIndent(indent)}FunctionDeclaration:\n`;
     prStr += `${prIndent(indent + 2)}Name: ${node.name.name}\n`;
-    prStr += `${prIndent(indent + 2)}Params:`;
+    prStr += `${prIndent(indent + 2)}Params:\n`;
 
     for (let param of node.params) {
-      prStr += this.print(param, indent + 4) + "\n";
+      prStr += this.print(param.name, indent + 4) + "\n";
     }
 
-    prStr += `${prIndent(indent + 2)}Body:`;
+    prStr += `${prIndent(indent + 2)}Body:\n`;
 
     for (let expr of node.body) {
       prStr += this.print(expr, indent + 4) + "\n";
@@ -153,13 +157,13 @@ class ASTPrinter {
    */
   printLambdaExpression(node, indent) {
     let prStr = `${prIndent(indent)}FunctionDeclaration:\n`;
-    prStr += `${prIndent(indent + 2)}Params:`;
+    prStr += `${prIndent(indent + 2)}Params:\n`;
 
     for (let param of node.params) {
-      prStr += this.print(param, indent + 4) + "\n";
+      prStr += this.print(param.name, indent + 4) + "\n";
     }
 
-    prStr += `${prIndent(indent + 2)}Body:`;
+    prStr += `${prIndent(indent + 2)}Body:\n`;
 
     for (let expr of node.body) {
       prStr += this.print(expr, indent + 4) + "\n";

--- a/src/printer/printAST.js
+++ b/src/printer/printAST.js
@@ -156,7 +156,7 @@ class ASTPrinter {
    * @returns {string}
    */
   printLambdaExpression(node, indent) {
-    let prStr = `${prIndent(indent)}FunctionDeclaration:\n`;
+    let prStr = `${prIndent(indent)}LambdaExpression:\n`;
     prStr += `${prIndent(indent + 2)}Params:\n`;
 
     for (let param of node.params) {

--- a/src/printer/printString.js
+++ b/src/printer/printString.js
@@ -22,6 +22,8 @@ export const printString = (value, withQuotes) => {
       return String(value);
     case "undefined":
       return "nil";
+    case "function":
+      return `Function ${value.name}`;
     case "object":
       if (value === null) {
         return "nil";

--- a/src/printer/printString.js
+++ b/src/printer/printString.js
@@ -23,7 +23,7 @@ export const printString = (value, withQuotes) => {
     case "undefined":
       return "nil";
     case "function":
-      return `Function: ${value.name ?? "lambda"}`;
+      return `Function: ${value.name || "lambda"}`;
     case "object":
       if (value === null) {
         return "nil";

--- a/src/printer/printString.js
+++ b/src/printer/printString.js
@@ -23,7 +23,7 @@ export const printString = (value, withQuotes) => {
     case "undefined":
       return "nil";
     case "function":
-      return `Function ${value.name}`;
+      return `Function: ${value.name ?? "lambda"}`;
     case "object":
       if (value === null) {
         return "nil";

--- a/src/printer/println.js
+++ b/src/printer/println.js
@@ -1,4 +1,4 @@
 import { printString } from "./printString.js";
 
 export const println = (input, withQuotes = true) =>
-  process.stdout.write(printString(input, withQuotes) + "\n");
+  console.log(printString(input, withQuotes));

--- a/src/reader/read.js
+++ b/src/reader/read.js
@@ -292,8 +292,9 @@ const readRecordPattern = (reader, srcloc) => {
  */
 const readMemberExpression = (reader, left) => {
   const tok = reader.next();
+  const prec = getPrec(tok);
   reader.expect(TokenTypes.Dot, tok.type);
-  const property = readExpr(reader);
+  const property = readExpr(reader, prec);
   return {
     type: "MemberExpression",
     object: left,

--- a/src/runtime/conversion.js
+++ b/src/runtime/conversion.js
@@ -11,10 +11,6 @@ export const makeWandaValue = (val) => {
   switch (typeof val) {
     case "undefined":
       return null;
-    case "function":
-      if (!hasMetaField(val, "wanda")) {
-        return makeFunction(val);
-      }
     case "object":
       if (val === null) {
         return null;

--- a/src/runtime/conversion.js
+++ b/src/runtime/conversion.js
@@ -37,6 +37,10 @@ export const makeJSValue = (val) => {
 
   switch (typeof val) {
     case "object":
+      if (val === null) {
+        return null;
+      }
+
       if (hasDict(val)) {
         return val[makeKeyword("dict")];
       }

--- a/src/runtime/makeFunction.js
+++ b/src/runtime/makeFunction.js
@@ -1,3 +1,4 @@
+import objectHash from "object-hash";
 import { curryN } from "ramda";
 import { makeWandaValue } from "./conversion.js";
 import { addMetaField } from "./object.js";
@@ -13,8 +14,11 @@ export const makeFunction = (func, { contract = "" } = {}) => {
 
     return val;
   });
+  const hash = objectHash(fn);
+
   addMetaField(fn, "wanda", true);
   addMetaField(fn, "arity", func.length);
+  addMetaField(fn, "name", hash);
 
   if (contract !== "") {
     Object.defineProperty(fn, "contract", {
@@ -24,6 +28,13 @@ export const makeFunction = (func, { contract = "" } = {}) => {
       value: parseContract(contract),
     });
   }
+
+  Object.defineProperty(fn, "name", {
+    enumerable: false,
+    configurable: false,
+    writable: false,
+    value: hash,
+  });
 
   return fn;
 };

--- a/src/runtime/makeFunction.js
+++ b/src/runtime/makeFunction.js
@@ -14,14 +14,6 @@ export const makeFunction = (func) => {
   });
   addMetaField(fn, "wanda", true);
   addMetaField(fn, "arity", func.length);
-  addMetaField(fn, "name", func.name);
-
-  Object.defineProperty(fn, "name", {
-    enumerable: false,
-    writable: false,
-    configurable: false,
-    value: func.name,
-  });
 
   return fn;
 };

--- a/src/runtime/makeFunction.js
+++ b/src/runtime/makeFunction.js
@@ -1,9 +1,19 @@
+import { curryN } from "ramda";
 import { makeWandaValue } from "./conversion.js";
 import { addMetaField } from "./object.js";
 
 export const makeFunction = (func) => {
-  const fn = (...args) => makeWandaValue(func(...args));
+  let fn = curryN(func.length, (...args) => {
+    const val = makeWandaValue(func(...args));
+
+    if (typeof val === "function") {
+      return makeFunction(val);
+    }
+
+    return val;
+  });
   addMetaField(fn, "wanda", true);
+  addMetaField(fn, "arity", func.length);
 
   return fn;
 };

--- a/src/runtime/makeFunction.js
+++ b/src/runtime/makeFunction.js
@@ -1,8 +1,9 @@
 import { curryN } from "ramda";
 import { makeWandaValue } from "./conversion.js";
 import { addMetaField } from "./object.js";
+import { parseContract } from "./parseContract.js";
 
-export const makeFunction = (func) => {
+export const makeFunction = (func, { contract = "" } = {}) => {
   let fn = curryN(func.length, (...args) => {
     const val = makeWandaValue(func(...args));
 
@@ -14,6 +15,15 @@ export const makeFunction = (func) => {
   });
   addMetaField(fn, "wanda", true);
   addMetaField(fn, "arity", func.length);
+
+  if (contract !== "") {
+    Object.defineProperty(fn, "contract", {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: parseContract(contract),
+    });
+  }
 
   return fn;
 };

--- a/src/runtime/makeFunction.js
+++ b/src/runtime/makeFunction.js
@@ -14,6 +14,14 @@ export const makeFunction = (func) => {
   });
   addMetaField(fn, "wanda", true);
   addMetaField(fn, "arity", func.length);
+  addMetaField(fn, "name", func.name);
+
+  Object.defineProperty(fn, "name", {
+    enumerable: false,
+    writable: false,
+    configurable: false,
+    value: func.name,
+  });
 
   return fn;
 };

--- a/src/runtime/parseContract.js
+++ b/src/runtime/parseContract.js
@@ -1,0 +1,7 @@
+import { tokenize } from "../lexer/tokenize.js";
+import { read } from "../reader/read.js";
+import { parseTypeAnnotation } from "../parser/parseTypeAnnotation.js";
+import { fromTypeAnnotation } from "../typechecker/fromTypeAnnotation.js";
+
+export const parseContract = (code) =>
+  fromTypeAnnotation(parseTypeAnnotation(read(tokenize(code)).car));

--- a/src/shared/exceptions.js
+++ b/src/shared/exceptions.js
@@ -14,6 +14,7 @@ export class Exception extends Error {
   constructor(msg, stack = []) {
     super(msg);
     this.wandaStack = stack;
+    this[Symbol.for(":dict")] = { message: msg };
   }
 
   /**

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -122,6 +122,14 @@ export class TypeChecker {
   }
 
   /**
+   * Type checks a function declaration
+   * @param {import("../parser/ast.js").FunctionDeclaration} node
+   * @param {TypeEnvironment} env
+   * @returns {TypedAST}
+   */
+  checkFunctionDeclaration(node, env) {}
+
+  /**
    * Type checks a keyword literal
    * @param {import("../parser/ast").KeywordLiteral} node
    * @param {TypeEnvironment} env
@@ -129,6 +137,16 @@ export class TypeChecker {
    */
   checkKeyword(node, env) {
     return { ...node, type: infer(node, env) };
+  }
+
+  /**
+   * Type checks a lambda expression
+   * @param {import("../parser/ast.js").LambdaExpression} node
+   * @param {TypeEnvironment} env
+   * @returns {TypedAST}
+   */
+  checkLambdaExpression(node, env) {
+    return {...node, type: infer(node, env.extend("Lambda"))};
   }
 
   checkMemberExpression(node, env) {

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -88,6 +88,10 @@ export class TypeChecker {
         return this.checkRecordLiteral(node, env);
       case ASTTypes.VectorLiteral:
         return this.checkVectorLiteral(node, env);
+      case ASTTypes.FunctionDeclaration:
+        return this.checkFunctionDeclaration(node, env);
+      case ASTTypes.LambdaExpression:
+        return this.checkLambdaExpression(node, env);
       default:
         throw new Exception(`Type checking not implemented for ${node.kind}`);
     }
@@ -156,7 +160,7 @@ export class TypeChecker {
    * @returns {TypedAST}
    */
   checkFunctionDeclaration(node, env) {
-    if (node.env) {
+    if (!node.env) {
       node.env = env.extend(node.name.name);
     }
 
@@ -184,7 +188,7 @@ export class TypeChecker {
    * @returns {TypedAST}
    */
   checkLambdaExpression(node, env) {
-    if (node.env) {
+    if (!node.env) {
       node.env = env.extend("Lambda");
     }
 

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -167,6 +167,10 @@ export class TypeChecker {
     const funcEnv = node.env;
     const type = infer(node, funcEnv);
 
+    if (funcEnv.checkingOn) {
+      env.checkingOn = funcEnv.checkingOn;
+    }
+
     env.set(node.name.name, type);
     return { ...node, type };
   }
@@ -194,6 +198,10 @@ export class TypeChecker {
 
     const funcEnv = node.env;
     const type = infer(node, funcEnv);
+
+    if (funcEnv.checkingOn) {
+      env.checkingOn = funcEnv.checkingOn;
+    }
 
     return { ...node, type };
   }

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -276,7 +276,10 @@ export class TypeChecker {
           if (node.lhv.rest && i === node.lhv.members.length - 1) {
             env.set(mem.name, type);
           } else {
-            env.set(mem.name, type.vectorType ? type.vectorType : type.listType);
+            env.set(
+              mem.name,
+              type.vectorType ? type.vectorType : type.listType
+            );
           }
           i++;
         }

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -169,6 +169,7 @@ export class TypeChecker {
 
     if (funcEnv.checkingOn) {
       env.checkingOn = funcEnv.checkingOn;
+      check(node, type, funcEnv);
     }
 
     env.set(node.name.name, type);
@@ -201,6 +202,7 @@ export class TypeChecker {
 
     if (funcEnv.checkingOn) {
       env.checkingOn = funcEnv.checkingOn;
+      check(node, type, funcEnv);
     }
 
     return { ...node, type };

--- a/src/typechecker/TypeChecker.js
+++ b/src/typechecker/TypeChecker.js
@@ -268,7 +268,13 @@ export class TypeChecker {
     if (env.checkingOn) {
       const nameType = env.getType(node.lhv.name);
       check(node.expression, nameType, env);
-      return { ...node, type: nameType };
+      return {
+        kind: node.kind,
+        lhv: node.lhv,
+        expression: this.checkNode(node.expression, env),
+        srcloc: node.srcloc,
+        type: nameType,
+      };
     }
 
     return {

--- a/src/typechecker/check.js
+++ b/src/typechecker/check.js
@@ -17,6 +17,14 @@ export const check = (ast, type, env) => {
     return checkObject(ast, type, env);
   }
 
+  if (
+    (ast.kind === ASTTypes.FunctionDeclaration ||
+      ast.kind === ASTTypes.LambdaExpression) &&
+    Type.isFunctionType(type)
+  ) {
+    return checkFunction(ast, type, env);
+  }
+
   const inferredType = infer(ast, env);
 
   if (!isSubtype(inferredType, type)) {
@@ -30,7 +38,7 @@ export const check = (ast, type, env) => {
 };
 
 /**
- *
+ * Checks an object type
  * @param {import("../parser/ast.js").RecordLiteral} ast
  * @param {import("./types").Object} type
  * @param {TypeEnvironment} env
@@ -64,4 +72,40 @@ const checkObject = (ast, type, env) => {
 
     check(expr, pType, env);
   });
+};
+
+/**
+ * Checks a function type
+ * @param {import("../parser/ast.js").FunctionDeclaration|import("../parser/ast.js").LambdaExpression} ast
+ * @param {import("./types").FunctionType} type
+ * @param {TypeEnvironment} env
+ */
+const checkFunction = (ast, type, env) => {
+  if (type.params.length !== ast.params.length) {
+    throw new TypeException(
+      `Expected ${type.params.length} args; got ${ast.params.length}`,
+      ast.srcloc
+    );
+  }
+
+  const funcType = infer(ast, env);
+
+  type.params.forEach((p, i) => {
+    const pType = funcType.params[i];
+    if (!isSubtype(pType, p)) {
+      throw new TypeException(
+        `${Type.toString(pType)} is not a valid subtype of ${Type.toString(p)}`,
+        ast.srcloc
+      );
+    }
+  });
+
+  if (!isSubtype(funcType.ret, type.ret)) {
+    throw new TypeException(
+      `${Type.toString(funcType.ret)} is not a valid subtype of ${Type.toString(
+        type.ret
+      )}`,
+      ast.srcloc
+    );
+  }
 };

--- a/src/typechecker/check.js
+++ b/src/typechecker/check.js
@@ -88,7 +88,8 @@ const checkFunction = (ast, type, env) => {
     );
   }
 
-  const funcType = infer(ast, env);
+  const maybeType = env.get(ast.name.name);
+  const funcType = maybeType ? maybeType : infer(ast, env);
 
   type.params.forEach((p, i) => {
     const pType = funcType.params[i];

--- a/src/typechecker/check.js
+++ b/src/typechecker/check.js
@@ -88,7 +88,7 @@ const checkFunction = (ast, type, env) => {
     );
   }
 
-  const maybeType = env.get(ast.name.name);
+  const maybeType = env.get(ast.name?.name);
   const funcType = maybeType ? maybeType : infer(ast, env);
 
   type.params.forEach((p, i) => {

--- a/src/typechecker/constructors.js
+++ b/src/typechecker/constructors.js
@@ -79,4 +79,4 @@ export const object = (properties) => ({ kind: TypeTypes.Object, properties });
 /**
  * Undefined type constructor
  */
-export const undefinedType = ({ kind: TypeTypes.Undefined });
+export const undefinedType = { kind: TypeTypes.Undefined };

--- a/src/typechecker/constructors.js
+++ b/src/typechecker/constructors.js
@@ -75,3 +75,8 @@ export const vector = (vectorType) => ({
  * @returns {import("./types.js").Object}
  */
 export const object = (properties) => ({ kind: TypeTypes.Object, properties });
+
+/**
+ * Undefined type constructor
+ */
+export const undefinedType = ({ kind: TypeTypes.Undefined });

--- a/src/typechecker/fromTypeAnnotation.js
+++ b/src/typechecker/fromTypeAnnotation.js
@@ -54,6 +54,13 @@ export const fromTypeAnnotation = (
       }));
       return Type.object(propTypes);
     }
+    case TATypes.Function: {
+      const paramTypes = typeAnnotation.params.map((p) =>
+        fromTypeAnnotation(p, typeEnv)
+      );
+      const retType = fromTypeAnnotation(typeAnnotation.retType, typeEnv);
+      return Type.functionType(paramTypes, retType);
+    }
     default:
       throw new Exception(
         `Type not found for type annotation ${JSON.parse(

--- a/src/typechecker/fromTypeAnnotation.js
+++ b/src/typechecker/fromTypeAnnotation.js
@@ -59,7 +59,7 @@ export const fromTypeAnnotation = (
         fromTypeAnnotation(p, typeEnv)
       );
       const retType = fromTypeAnnotation(typeAnnotation.retType, typeEnv);
-      return Type.functionType(paramTypes, retType);
+      return Type.functionType(paramTypes, retType, typeAnnotation.variadic);
     }
     default:
       throw new Exception(

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -99,6 +99,8 @@ const inferCallExpression = (node, env) => {
     return Type.undefinedType;
   }
 
+  // handle partially applied functions
+
   if (env.checkingOn) {
     func.params.forEach((p, i, a) => {
       const argType = infer(node.args[i], env);

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -109,7 +109,7 @@ const inferCallExpression = (node, env) => {
     const params = func.params.slice(0, node.args.length);
 
     if (env.checkingOn) {
-      checkArgTypes(node, params, env);
+      checkArgTypes(node, params, env, func);
     }
 
     const newParams = func.params.slice(node.args.length);
@@ -117,20 +117,20 @@ const inferCallExpression = (node, env) => {
   }
 
   if (env.checkingOn) {
-    checkArgTypes(node, func.params, env);
+    checkArgTypes(node, func.params, env, func);
   }
 
   return func.ret;
 };
 
-const checkArgTypes = (node, params, env) => {
+const checkArgTypes = (node, params, env, func) => {
   params.forEach((p, i, a) => {
     const argType = infer(node.args[i], env);
     if (!isSubtype(argType, p)) {
-      const node = node.args[i];
+      const n = node.args[i];
       throw new TypeException(
         `${Type.toString(argType)} is not a subtype of ${Type.toString(p)}`,
-        node.srcloc
+        n.srcloc
       );
     }
 

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -327,5 +327,11 @@ const inferFunction = (node, env) => {
     );
   }
 
-  return Type.functionType(params, retType, node.variadic);
+  return Type.functionType(
+    params,
+    Type.isAny(retType) || Type.isUndefined(retType)
+      ? inferredRetType
+      : retType,
+    node.variadic
+  );
 };

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -96,6 +96,7 @@ const inferCallExpression = (node, env) => {
   if (Type.isAny(func)) {
     return Type.any;
   } else if (Type.isUndefined(func) || Type.isUndefined(func.ret)) {
+    // this should only happen during first typechecker pass
     return Type.undefinedType;
   }
 

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -69,15 +69,16 @@ const inferNil = () => Type.nil;
 const inferSymbol = (node, env) => {
   const name = node.name;
   const namedType = env.get(name);
-  const baseType = Type.isTypeAlias(namedType)
-    ? getAliasBase(namedType.name)
-    : namedType;
 
-  if (!namedType) {
-    throw new Exception(
-      `Type not found in current environment for ${name} at ${node.srcloc.file} ${node.srcloc.col}:${node.srcloc.col}`
-    );
+  if (namedType === undefined && env.checkingOn) {
+    throw new TypeException(`Type not found for name ${name}`, node.srcloc);
   }
+
+  const baseType = namedType && Type.isTypeAlias(namedType)
+    ? getAliasBase(namedType.name)
+    : namedType
+    ? namedType
+    : Type.any;
 
   return baseType;
 };

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -100,6 +100,13 @@ const inferCallExpression = (node, env) => {
     return Type.undefinedType;
   }
 
+  if (!func.variadic && node.args.length > func.params.length) {
+    throw new TypeException(
+      `Too many arguments for function: ${node.args.length} given; ${func.params.length} expected`,
+      node.srcloc
+    );
+  }
+
   // handle partially applied functions
   if (
     node.args.length <

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -115,7 +115,10 @@ const inferCallExpression = (node, env) => {
 
       if (func.variadic && i === a.length - 1) {
         if (!p.vectorType) {
-          throw new TypeException(`Rest parameter type must be vector; ${Type.toString(p)} given`, arg.srcloc)
+          throw new TypeException(
+            `Rest parameter type must be vector; ${Type.toString(p)} given`,
+            arg.srcloc
+          );
         }
         p = p.vectorType;
 

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -74,11 +74,12 @@ const inferSymbol = (node, env) => {
     throw new TypeException(`Type not found for name ${name}`, node.srcloc);
   }
 
-  const baseType = namedType && Type.isTypeAlias(namedType)
-    ? getAliasBase(namedType.name)
-    : namedType
-    ? namedType
-    : Type.any;
+  const baseType =
+    namedType && Type.isTypeAlias(namedType)
+      ? getAliasBase(namedType.name)
+      : namedType
+      ? namedType
+      : Type.any;
 
   return baseType;
 };
@@ -94,6 +95,8 @@ const inferCallExpression = (node, env) => {
 
   if (Type.isAny(func)) {
     return Type.any;
+  } else if (Type.isUndefined(func) || Type.isUndefined(func.ret)) {
+    return Type.undefinedType;
   }
 
   if (

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -107,23 +107,28 @@ const inferCallExpression = (node, env) => {
       const argType = infer(node.args[i], env);
       if (!isSubtype(argType, p)) {
         const node = node.args[i];
-        throw new Exception(
-          `${Type.toString(argType)} is not a subtype of ${Type.toString(
-            p
-          )} at ${node.srcloc.file} ${node.srcloc.line}:${node.srcloc.col}`
+        throw new TypeException(
+          `${Type.toString(argType)} is not a subtype of ${Type.toString(p)}`,
+          node.srcloc
         );
       }
 
-      if (i === a.length - 1) {
+      if (func.variadic && i === a.length - 1) {
+        if (!p.vectorType) {
+          throw new TypeException(`Rest parameter type must be vector; ${Type.toString(p)} given`, arg.srcloc)
+        }
+        p = p.vectorType;
+
         for (let arg of node.args.slice(i)) {
           const argType = infer(arg, env);
 
           if (!isSubtype(argType, p)) {
             const node = node.args[i];
-            throw new Exception(
+            throw new TypeException(
               `${Type.toString(argType)} is not a subtype of ${Type.toString(
                 p
-              )} at ${node.srcloc.file} ${node.srcloc.line}:${node.srcloc.col}`
+              )}`,
+              node.srcloc
             );
           }
         }

--- a/src/typechecker/infer.js
+++ b/src/typechecker/infer.js
@@ -99,17 +99,6 @@ const inferCallExpression = (node, env) => {
     return Type.undefinedType;
   }
 
-  if (
-    node.args.length !== func.params.length ||
-    (func.variadic && node.args.length >= func.params.length - 1)
-  ) {
-    throw new Exception(
-      `Expected${func.variadic ? " at least " : " "}arguments; ${
-        node.args.length
-      } given at ${node.srcloc.file} ${node.srcloc.line}:${node.srcloc.col}`
-    );
-  }
-
   if (env.checkingOn) {
     func.params.forEach((p, i, a) => {
       const argType = infer(node.args[i], env);

--- a/src/typechecker/isSubtype.js
+++ b/src/typechecker/isSubtype.js
@@ -46,5 +46,13 @@ export const isSubtype = (type1, type2) => {
   // a type should only be undefined on the first pass through the checker
   if (Type.isUndefined(type1) || Type.isUndefined(type2)) return true;
 
+  if (Type.isFunctionType(type1) && Type.isFunctionType(type2)) {
+    return (
+      type1.params.length === type2.params.length &&
+      a.params.every((a, i) => isSubtype(b.params[i], a)) &&
+      isSubtype(a.ret, b.ret)
+    );
+  }
+
   return false;
 };

--- a/src/typechecker/isSubtype.js
+++ b/src/typechecker/isSubtype.js
@@ -43,5 +43,8 @@ export const isSubtype = (type1, type2) => {
     });
   }
 
+  // a type should only be undefined on the first pass through the checker
+  if (Type.isUndefined(type1) || Type.isUndefined(type2)) return true;
+
   return false;
 };

--- a/src/typechecker/types.js
+++ b/src/typechecker/types.js
@@ -14,6 +14,7 @@ export const TypeTypes = {
   Vector: "Vector",
   Property: "Property",
   Object: "Object",
+  Undefined: "Undefined"
 };
 /**
  * @typedef Any
@@ -74,7 +75,11 @@ export const TypeTypes = {
  * @prop {Property[]} properties
  */
 /**
- * @typedef {Number|String|Boolean|Keyword|Nil} PrimitiveTypes
+ * @typedef Undefined
+ * @prop {TypeTypes.Undefined} kind
+ */
+/**
+ * @typedef {Number|String|Boolean|Keyword|Nil|Undefined} PrimitiveTypes
  */
 /**
  * @typedef {Any|PrimitiveTypes|FunctionType|TypeAlias|List|Vector|Object} Type

--- a/src/typechecker/types.js
+++ b/src/typechecker/types.js
@@ -14,7 +14,7 @@ export const TypeTypes = {
   Vector: "Vector",
   Property: "Property",
   Object: "Object",
-  Undefined: "Undefined"
+  Undefined: "Undefined",
 };
 /**
  * @typedef Any

--- a/src/typechecker/validators.js
+++ b/src/typechecker/validators.js
@@ -98,3 +98,12 @@ export const isVector = (type) => {
 export const isObject = (type) => {
   return type.kind === TypeTypes.Object;
 };
+
+/**
+ * Checks if current type is undefined
+ * @param {import("./types.js").Type} type
+ * @returns {boolean}
+ */
+export const isUndefined = (type) => {
+  return type.kind === TypeTypes.Undefined;
+}

--- a/src/typechecker/validators.js
+++ b/src/typechecker/validators.js
@@ -106,4 +106,4 @@ export const isObject = (type) => {
  */
 export const isUndefined = (type) => {
   return type.kind === TypeTypes.Undefined;
-}
+};

--- a/src/visitor/Visitor.js
+++ b/src/visitor/Visitor.js
@@ -63,6 +63,8 @@ export class Visitor {
         return this.visitRecordPattern(node);
       case ASTTypes.MemberExpression:
         return this.visitMemberExpression(node);
+      case ASTTypes.Param:
+        return this.visitParam(node);
       default:
         throw new SyntaxException(node.kind, node.srcloc);
     }
@@ -104,12 +106,46 @@ export class Visitor {
   }
 
   /**
+   * FunctionDeclaration node visitor
+   * @param {import("../parser/ast.js").FunctionDeclaration} node
+   * @returns {import("../parser/ast.js").FunctionDeclaration}
+   */
+  visitFunctionDeclaration(node) {
+    const params = node.params.map(this.visit);
+    /** @type {AST[]} */
+    let body = [];
+
+    for (let expr of node.body) {
+      body.push(this.visit(expr));
+    }
+
+    return { ...node, params, body };
+  }
+
+  /**
    * KeywordLiteral node visitor
    * @param {import("../parser/ast").KeywordLiteral} node
    * @returns {import("../parser/ast").KeywordLiteral}
    */
   visitKeywordLiteral(node) {
     return node;
+  }
+
+  /**
+   * LambdaExpression node visitor
+   * @param {import("../parser/ast.js").LambdaExpression} node
+   * @returns {import("../parser/ast.js").LambdaExpression}
+   */
+  visitLambdaExpression(node) {
+    const params = node.params.map(this.visit);
+    /** @type {AST[]} */
+    let body = [];
+
+    for (let expr of node.body) {
+      body.push(this.visit(expr));
+    }
+
+    return { ...node, params, body };
   }
 
   /**
@@ -138,6 +174,15 @@ export class Visitor {
    * @returns {import("../parser/ast").NumberLiteral}
    */
   visitNumberLiteral(node) {
+    return node;
+  }
+
+  /**
+   * Param node visitor
+   * @param {import("../parser/ast.js").Param} node
+   * @returns {import("../parser/ast.js").Param}
+   */
+  visitParam(node) {
     return node;
   }
 

--- a/src/visitor/Visitor.js
+++ b/src/visitor/Visitor.js
@@ -6,11 +6,28 @@ import { SyntaxException } from "../shared/exceptions.js";
  */
 export class Visitor {
   /**
+   * Constructs a Visitor
+   * @param {AST} program
+   */
+  constructor(program) {
+    this.program = program;
+  }
+
+  /**
+   * Static constructor
+   * @param {AST} program
+   * @returns {Visitor}
+   */
+  static new(program) {
+    return new Visitor(program);
+  }
+
+  /**
    * Visitor dispatch method
    * @param {AST} node
    * @returns {AST}
    */
-  visit(node) {
+  visit(node = this.program) {
     switch (node.kind) {
       case ASTTypes.Program:
         return this.visitProgram(node);

--- a/src/visitor/Visitor.js
+++ b/src/visitor/Visitor.js
@@ -65,6 +65,10 @@ export class Visitor {
         return this.visitMemberExpression(node);
       case ASTTypes.Param:
         return this.visitParam(node);
+      case ASTTypes.FunctionDeclaration:
+        return this.visitFunctionDeclaration(node);
+      case ASTTypes.LambdaExpression:
+        return this.visitLambdaExpression(node);
       default:
         throw new SyntaxException(node.kind, node.srcloc);
     }

--- a/src/visitor/Visitor.js
+++ b/src/visitor/Visitor.js
@@ -1,0 +1,225 @@
+import { AST, ASTTypes } from "../parser/ast.js";
+import { SyntaxException } from "../shared/exceptions.js";
+
+/**
+ * Abstract class to be inherited by other visitors
+ */
+export class Visitor {
+  /**
+   * Visitor dispatch method
+   * @param {AST} node
+   * @returns {AST}
+   */
+  visit(node) {
+    switch (node.kind) {
+      case ASTTypes.Program:
+        return this.visitProgram(node);
+      case ASTTypes.NumberLiteral:
+        return this.visitNumberLiteral(node);
+      case ASTTypes.StringLiteral:
+        return this.visitStringLiteral(node);
+      case ASTTypes.BooleanLiteral:
+        return this.visitBooleanLiteral(node);
+      case ASTTypes.KeywordLiteral:
+        return this.visitKeywordLiteral(node);
+      case ASTTypes.NilLiteral:
+        return this.visitNilLiteral(node);
+      case ASTTypes.Symbol:
+        return this.visitSymbol(node);
+      case ASTTypes.CallExpression:
+        return this.visitCallExpression(node);
+      case ASTTypes.VariableDeclaration:
+        return this.visitVariableDeclaration(node);
+      case ASTTypes.SetExpression:
+        return this.visitSetExpression(node);
+      case ASTTypes.DoExpression:
+        return this.visitDoExpression(node);
+      case ASTTypes.TypeAlias:
+        return this.visitTypeAlias(node);
+      case ASTTypes.VectorLiteral:
+        return this.visitVectorLiteral(node);
+      case ASTTypes.VectorPattern:
+        return this.visitVectorPattern(node);
+      case ASTTypes.RecordLiteral:
+        return this.visitRecordLiteral(node);
+      case ASTTypes.RecordPattern:
+        return this.visitRecordPattern(node);
+      case ASTTypes.MemberExpression:
+        return this.visitMemberExpression(node);
+      default:
+        throw new SyntaxException(node.kind, node.srcloc);
+    }
+  }
+
+  /**
+   * BooleanLiteral node visitor
+   * @param {import("../parser/ast").BooleanLiteral} node
+   * @returns {import("../parser/ast").BooleanLiteral}
+   */
+  visitBooleanLiteral(node) {
+    return node;
+  }
+
+  /**
+   * CallExpression node visitor
+   * @param {import("../parser/ast").CallExpression} node
+   * @returns {import("../parser/ast").CallExpression}
+   */
+  visitCallExpression(node) {
+    const func = this.visit(node.func);
+    const args = node.args.map(this.visit);
+    return { ...node, func, args };
+  }
+
+  /**
+   * DoExpression node visitor
+   * @param {import("../parser/ast").DoExpression} node
+   * @returns {import("../parser/ast").DoExpression}
+   */
+  visitDoExpression(node) {
+    let body = [];
+
+    for (let n of node.body) {
+      body.push(this.visit(n));
+    }
+
+    return { ...node, body };
+  }
+
+  /**
+   * KeywordLiteral node visitor
+   * @param {import("../parser/ast").KeywordLiteral} node
+   * @returns {import("../parser/ast").KeywordLiteral}
+   */
+  visitKeywordLiteral(node) {
+    return node;
+  }
+
+  /**
+   * MemberExpression node visitor
+   * @param {import("../reader/read").MemberExpression} node
+   * @returns {import("../parser/ast").MemberExpression}
+   */
+  visitMemberExpression(node) {
+    const object = this.visit(node.object);
+    const property = this.visit(node.property);
+    return { ...node, object, property };
+  }
+
+  /**
+   * NilLiteral node visitor
+   * @param {import("../parser/ast").NilLiteral} node
+   * @returns {import("../parser/ast").NilLiteral}
+   */
+  visitNilLiteral(node) {
+    return node;
+  }
+
+  /**
+   * NumberLiteral node visitor
+   * @param {import("../parser/ast").NumberLiteral} node
+   * @returns {import("../parser/ast").NumberLiteral}
+   */
+  visitNumberLiteral(node) {
+    return node;
+  }
+
+  /**
+   * Program node visitor
+   * @param {import("../parser/ast").Program} node
+   * @returns {import("../parser/ast").Program}
+   */
+  visitProgram(node) {
+    let body = [];
+    for (let n of node.body) {
+      body.push(this.visit(n));
+    }
+
+    return { ...node, body };
+  }
+
+  /**
+   * RecordLiteral node visitor
+   * @param {import("../parser/ast").RecordLiteral} node
+   * @returns {import("../parser/ast").RecordLiteral}
+   */
+  visitRecordLiteral(node) {
+    return node;
+  }
+
+  /**
+   * RecordPattern node visitor
+   * @param {import("../parser/ast").RecordPattern} node
+   * @returns {import("../parser/ast").RecordPattern}
+   */
+  visitRecordPattern(node) {
+    return node;
+  }
+
+  /**
+   * SetExpression node visitor
+   * @param {import("../parser/ast").SetExpression} node
+   * @returns {import("../parser/ast").SetExpression}
+   */
+  visitSetExpression(node) {
+    const lhv = this.visit(node.lhv);
+    const expression = this.visit(node.expression);
+    return { ...node, lhv, expression };
+  }
+
+  /**
+   * StringLiteral node visitor
+   * @param {import("../parser/ast").StringLiteral} node
+   * @returns {import("../parser/ast").StringLiteral}
+   */
+  visitStringLiteral(node) {
+    return node;
+  }
+
+  /**
+   * Symbol node visitor
+   * @param {import("../parser/ast").Symbol} node
+   * @returns {import("../parser/ast").Symbol}
+   */
+  visitSymbol(node) {
+    return node;
+  }
+
+  /**
+   * TypeAlias node visitor
+   * @param {import("../parser/ast").TypeAlias} node
+   * @returns {import("../parser/ast").TypeAlias}
+   */
+  visitTypeAlias(node) {
+    return node;
+  }
+
+  /**
+   * VariableDeclaration node visitor
+   * @param {import("../parser/ast").VariableDeclaration} node
+   * @returns {import("../parser/ast").VariableDeclaration}
+   */
+  visitVariableDeclaration(node) {
+    const lhv = this.visit(node.lhv);
+    const expression = this.visit(node.expression);
+    return { ...node, lhv, expression };
+  }
+
+  /**
+   * VectorLiteral node visitor
+   * @param {import("../parser/ast").VectorLiteral} node
+   * @returns {import("../parser/ast").VectorLiteral}
+   */
+  visitVectorLiteral(node) {
+    return node;
+  }
+
+  /**
+   * VectorPattern node visitor
+   * @param {import("../parser/ast").VectorPattern} node
+   * @returns {import("../parser/ast").VectorPattern}
+   */
+  visitVectorPattern(node) {
+    return node;
+  }
+}

--- a/src/visitor/Visitor.js
+++ b/src/visitor/Visitor.js
@@ -90,7 +90,7 @@ export class Visitor {
    */
   visitCallExpression(node) {
     const func = this.visit(node.func);
-    const args = node.args.map(this.visit);
+    const args = node.args.map(this.visit.bind(this));
     return { ...node, func, args };
   }
 
@@ -115,7 +115,7 @@ export class Visitor {
    * @returns {import("../parser/ast.js").FunctionDeclaration}
    */
   visitFunctionDeclaration(node) {
-    const params = node.params.map(this.visit);
+    const params = node.params.map(this.visit.bind(this));
     /** @type {AST[]} */
     let body = [];
 
@@ -141,7 +141,7 @@ export class Visitor {
    * @returns {import("../parser/ast.js").LambdaExpression}
    */
   visitLambdaExpression(node) {
-    const params = node.params.map(this.visit);
+    const params = node.params.map(this.visit.bind(this));
     /** @type {AST[]} */
     let body = [];
 


### PR DESCRIPTION
- `def` and `fn` forms
- `def` form desugars to `(var <name> (fn ...))`
- Optional type annotations
- All functions are curried
- Functions can be variadic
- More metadata for `rt.makeFunction`
- Annotations for function types
- Add function contracts in core library
- Add generic Visitor class and subclass it for desugaring